### PR TITLE
hee-vendor: fix --check tempdir cleanup (RETURN trap)

### DIFF
--- a/tooling/bin/hee-vendor
+++ b/tooling/bin/hee-vendor
@@ -73,8 +73,8 @@ hee_vendor__check_mode() {
   status_before="$(git -C "$target_root" status --porcelain 2>/dev/null || true)"
 
   # Render what vendoring would produce into a temp workspace (no writes to target).
-  tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  tmp=\"$(mktemp -d)\" || { echo \"ERROR: mktemp failed\"; return 94; }
+  trap '[[ -n \"${tmp:-}\" ]] && rm -rf \"${tmp:-}\"' RETURN
   work="$tmp/work"
   mkdir -p "$work"
 


### PR DESCRIPTION
Fixes a --check mode bug under set -euo pipefail where a tempdir cleanup trap used EXIT while tmp was local, causing 'tmp: unbound variable' at script exit. Uses a nounset-safe RETURN trap scoped to the check function and guards mktemp failure.