### PR TITLE
tools(oper): add git investigation scripts (iteration-safe)

### DIFF
--- a/tools/auto/README.md
+++ b/tools/auto/README.md
@@ -1,0 +1,8 @@
+# tools/auto
+
+Automation-oriented tools.
+
+Rules:
+- Intended for CI/cron/agent use.
+- May use strict bash settings (set -euo pipefail) when appropriate.
+- Must be deterministic and non-interactive by default.

--- a/tools/oper/README.md
+++ b/tools/oper/README.md
@@ -1,0 +1,8 @@
+# tools/oper
+
+Operator-only tools.
+
+Rules:
+- Intended for manual, interactive use.
+- Must be safe in iteration (avoid pipefail by default; tolerate partial failures).
+- Must not modify repo state unless explicitly named/flagged to do so.

--- a/tools/oper/git/cherry-picks-since.sh
+++ b/tools/oper/git/cherry-picks-since.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# cherry-picks-since.sh: list commits that look like cherry-picks since a base ref/sha
+# Matches the standard -x trailer: "cherry picked from commit ..."
+
+if [ "${1:-}" = "" ]; then
+  echo "usage: $0 <base-ref-or-sha> [<range-tip>]" >&2
+  exit 2
+fi
+
+BASE="$1"
+TIP="${2:-HEAD}"
+
+git log --grep='cherry picked from commit' \
+  --format='%h %ci %an %s' \
+  "${BASE}..${TIP}" 2>/dev/null || true

--- a/tools/oper/git/dad.sh
+++ b/tools/oper/git/dad.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# dad.sh: detect branches that look like automation churn (heuristic)
+# Oper-iteration safe: no errexit/pipefail; tolerate partial failures.
+
+THRESH="${THRESH:-10}"
+PAT="${PAT:-'(regen|generated|format|lint|pre-commit|autofix|chore|workflow|manifest|integrity|lock|deps|bump|vendor|sync)'}"
+MAX_BRANCHES="${MAX_BRANCHES:-25}"
+
+git fetch -p >/dev/null 2>&1 || true
+
+git for-each-ref --format='%(refname:short)' refs/heads 2>/dev/null \
+| rg -v '^main$' 2>/dev/null \
+| while IFS= read -r b; do
+    ahead="$(git rev-list --count "main..$b" 2>/dev/null || echo 0)"
+    case "$ahead" in (''|*[!0-9]*) ahead=0 ;; esac
+    [ "$ahead" -le "$THRESH" ] && continue
+
+    sus="$(git log --format='%s' -n 30 "$b" 2>/dev/null | rg -ic "$PAT" 2>/dev/null || echo 0)"
+    case "$sus" in (''|*[!0-9]*) sus=0 ;; esac
+
+    if [ "$sus" -ge 15 ]; then
+      printf "%-40s ahead=%4s suspicious=%2s/30\n" "$b" "$ahead" "$sus"
+    fi
+  done 2>/dev/null \
+| sort -k2,2nr 2>/dev/null \
+| head -"$MAX_BRANCHES" 2>/dev/null

--- a/tools/oper/git/last-touch.sh
+++ b/tools/oper/git/last-touch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# last-touch.sh: list files by last git-touch time (approx repo-wide "ls -lt", but meaningful)
+# Usage: last-touch.sh [N]
+# Prints: "<iso-date> <sha> <path>"
+
+N="${1:-200}"
+
+git ls-files 2>/dev/null \
+| while IFS= read -r f; do
+    line="$(git log -1 --format='%ci %h' -- "$f" 2>/dev/null || true)"
+    [ -n "$line" ] && printf "%s\t%s\n" "$line" "$f"
+  done \
+| sort -r 2>/dev/null \
+| head -"$N" 2>/dev/null


### PR DESCRIPTION
Add operator-only git forensics scripts (dad/cherry-picks-since/last-touch) and minimal tools/oper vs tools/auto separation docs. No CI changes.