### PR TITLE
fix: extract shell from pre-commit YAML hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,32 +59,28 @@ repos:
 
       - id: hee-security-check
         name: HEE Security Check
-        entry: | 
-          bash -c 'echo "🔍 Running HEE security checks..." && if grep -r "password\|secret\|key\|token" --include="*.md" --include="*.py" --include="*.js" --include="*.json" . | grep -v "docs/HEE_POLICY.md" | grep -v "prompts/PROMPTING_RULES.md" | grep -v "test\|example\|demo" | head -1; then echo "⚠️  Potential sensitive information found"; else echo "✅ No obvious security issues"; fi'
+        entry: scripts/pre-commit/hee-security-check
         language: system
         files: '.*'
         pass_filenames: false
 
       - id: hee-formatting-check
         name: HEE Formatting Check
-        entry: | 
-          bash -c 'echo "🔍 Checking HEE formatting standards..." && if [ -f "docs/STATE_CAPSULES/2026-01-24/HEE-Current-Tasks.md" ]; then echo "✅ State capsule formatting check passed"; else echo "⚠️  State capsule formatting may need attention"; fi'
+        entry: scripts/pre-commit/hee-formatting-check
         language: system
         files: '.*'
         pass_filenames: false
 
       - id: hee-violation-check
         name: HEE Violation Prevention Check
-        entry: | 
-          bash -c 'echo "🔍 Running HEE violation prevention check..." && ./scripts/violation_checker.sh'
+        entry: scripts/pre-commit/hee-violation-check
         language: system
         files: '.*'
         pass_filenames: false
 
       - id: hee-agent-instruction-check
         name: HEE Agent Instruction Check
-        entry: | 
-          bash -c 'echo "📋 HEE Agent Instructions:" && echo "⚠️  If this pre-commit hook blocks your commit, it is working correctly!" && echo "📝 Report the violation in your output and document it in the state capsule" && echo "🔧 This is expected behavior - the system is preventing violations" && echo "✅ Always update the state capsule with violation reports before pushing" && echo "🎯 Violations should be documented, not bypassed"'
+        entry: scripts/pre-commit/hee-agent-instruction-check
         language: system
         files: '.*'
         pass_filenames: false

--- a/scripts/pre-commit/hee-agent-instruction-check
+++ b/scripts/pre-commit/hee-agent-instruction-check
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "📋 HEE Agent Instructions:"
+echo "⚠️  If this pre-commit hook blocks your commit, it is working correctly!"
+echo "📝 Report the violation in your output and document it in the state capsule"
+echo "🔧 This is expected behavior - the system is preventing violations"
+echo "✅ Always update the state capsule with violation reports before pushing"
+echo "🎯 Violations should be documented, not bypassed"

--- a/scripts/pre-commit/hee-formatting-check
+++ b/scripts/pre-commit/hee-formatting-check
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "🔍 Checking HEE formatting standards..."
+if [ -f "docs/STATE_CAPSULES/2026-01-24/HEE-Current-Tasks.md" ]; then
+  echo "✅ State capsule formatting check passed"
+else
+  echo "⚠️  State capsule formatting may need attention"
+fi

--- a/scripts/pre-commit/hee-security-check
+++ b/scripts/pre-commit/hee-security-check
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "🔍 Running HEE security checks..."
+if grep -R -nE '(password|secret|key|token)' \
+  --include="*.md" --include="*.py" --include="*.js" --include="*.json" . \
+  | grep -v "docs/HEE_POLICY.md" \
+  | grep -v "prompts/PROMPTING_RULES.md" \
+  | grep -vE '(test|example|demo)' \
+  | head -1 >/dev/null
+then
+  echo "⚠️  Potential sensitive information found"
+else
+  echo "✅ No obvious security issues"
+fi

--- a/scripts/pre-commit/hee-violation-check
+++ b/scripts/pre-commit/hee-violation-check
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "🔍 Running HEE violation prevention check..."
+./scripts/violation_checker.sh


### PR DESCRIPTION
## What
Extract inline shell from `.pre-commit-config.yaml` into executable scripts under `scripts/pre-commit/`.

## Why
- Inline shell inside YAML is fragile and violates HEE guardrails.
- Externalizing scripts makes hooks testable, auditable, and less error-prone.
- ({}) mdshell + explicit rc lines materially increased operator confidence and trace quality.

## Changes
- `.pre-commit-config.yaml`: 4 hooks changed from `entry: | bash -c ...` to script paths
- Added executable scripts:
  - `scripts/pre-commit/hee-security-check`
  - `scripts/pre-commit/hee-formatting-check`
  - `scripts/pre-commit/hee-violation-check`
  - `scripts/pre-commit/hee-agent-instruction-check`

## Evidence (on disk)
- SUPER GREEN card:
  `/home/spencer/.hee/evidence/69898aea-995c-8327-868d-9ad2bae89b2c/cards/super-green.fix-shell-in-yaml-for-service.20260209T082117Z.md`
- GOLD STAR card:
  `/home/spencer/.hee/evidence/69898aea-995c-8327-868d-9ad2bae89b2c/cards/gold-star.fix-shell-in-yaml-for-service.20260209T083609Z.md`
- Checkpoint:
  `/home/spencer/.hee/evidence/69898aea-995c-8327-868d-9ad2bae89b2c/checkpoints/checkpoint.fix-shell-in-yaml-for-service.20260209T082447Z.yaml`

## Verification
- `pre-commit run -a`: all green (includes yamllint + check-yaml)

## Follow-ups (intentional non-scope)
- Remaining `entry: |` blocks still exist; convert in a follow-up PR.
- One remaining hook appears to touch remotes (`git fetch origin`) — should be removed/reworked per “no remote ops unless explicitly requested”.
