### PR TITLE
Add CODEOWNERS: gate governance paths on your review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Governance-sensitive paths -- changes here need spencer's review,
+# not a self-merge. This is the "who can verify what" gate: an
+# approval here is the actual stamp, not a chat back-and-forth.
+
+/hee/contracts/    @spencerbutler
+/blueprints/       @spencerbutler
+/schemas/          @spencerbutler
+/hee/registries/   @spencerbutler


### PR DESCRIPTION
# 🎯 Purpose

The "stamp it, not a run-around" mechanism — CODEOWNERS + branch protection now require your actual GitHub approval on any PR touching `hee/contracts/`, `blueprints/`, `schemas/`, `hee/registries/`. This PR itself doesn't touch those paths, so it's a control to verify the mechanism doesn't misfire on unrelated changes.

## 🔗 Links

- Dogfooded immediately on #183, which does touch `hee/contracts/`