### PR TITLE
Add glass-access: permission-checked display/workspace control

### DIFF
--- a/tools/glass-access/README.md
+++ b/tools/glass-access/README.md
@@ -1,0 +1,40 @@
+# glass-access
+
+Access-controlled display/workspace ("slot") switching. Every action
+checks a real identity → allowed-slots mapping (`config.json`) before
+touching the display — not just bare `wmctrl`.
+
+## Status (2026-08-13)
+
+- **X11 backend (touchy): real, working, tested.** Dogfooded live —
+  denial correctly blocks an out-of-scope slot, success correctly
+  switches/wakes/raises for an allowed one. See `backends/x11.mjs`.
+- **Wayland backend: deliberately a stub**, not a guess. `backends/wayland.mjs`
+  throws a clear "not implemented" error rather than pretending to work.
+  Blocked on one fact: which machine/compositor this targets — per
+  spencer, that's an infra decision routed through claude@nuc-1
+  ("the metal is mine and I will have claude@nuc-1 direct that"), not
+  something to assume here. See the `project_wayland_display_control`
+  memory for the real research (wlrctl/wdotool/kdotool/swaymsg/hyprctl)
+  done ahead of that answer landing.
+
+## Usage
+
+```
+node glass-access.mjs status
+node glass-access.mjs whoami  --identity claude-touchy
+node glass-access.mjs switch  --identity claude-touchy --slot 2
+```
+
+## Design
+
+`glass-access.mjs` is backend-agnostic — it only knows "check identity
+against config, then call `backend.switchToSlot()` etc." Adding a real
+Wayland backend later means filling in `backends/wayland.mjs` with the
+same function signatures `x11.mjs` already has; nothing else changes.
+
+This supersedes `~/.local/bin/kiosk-switch.sh` for anything that needs
+real access control (e.g. touchy's own Claude session only being
+allowed on its own verification slot, not the dashboard/HA slots a
+human drives) — `kiosk-switch.sh` still works for a human just switching
+slots by hand, no permission model needed there.

--- a/tools/glass-access/backends/wayland-sway.mjs
+++ b/tools/glass-access/backends/wayland-sway.mjs
@@ -1,0 +1,64 @@
+// wayland-sway.mjs — real Sway backend, same interface as x11.mjs.
+// Target confirmed 2026-08-14 (human-execution-engine#193): all-in-one
+// Dell touchscreen kiosk, Sway compositor. UNTESTED — no access to the
+// physical machine yet, only its hostname/compositor are confirmed.
+// Written directly against Sway's own IPC (`swaymsg`), not the more
+// generic wlrctl/wdotool — swaymsg is simpler and more reliable when the
+// compositor is known specifically, rather than "some wlroots thing."
+import { execSync } from "child_process";
+
+function sway(cmd) {
+  return execSync(`swaymsg ${cmd}`, { encoding: "utf8" }).trim();
+}
+function swayJson(cmd) {
+  return JSON.parse(execSync(`swaymsg -t ${cmd}`, { encoding: "utf8" }));
+}
+
+export function switchToSlot(slotIndex) {
+  sway(`workspace number ${slotIndex}`);
+}
+
+export function wakeDisplay() {
+  sway(`'output * dpms on'`);
+}
+
+// Walks Sway's node tree looking for a window whose name/title contains
+// `windowMatch` — mirrors x11.mjs's findWindowId, returns a con_id instead
+// of an X11 window id (used the same way: passed back into the other
+// functions below via a `[con_id=...]` criteria selector).
+export function findWindowId(windowMatch) {
+  const tree = swayJson("get_tree");
+  let found = null;
+  (function walk(node) {
+    if (found) return;
+    if (node.name && node.name.includes(windowMatch)) { found = node.id; return; }
+    for (const child of node.nodes || []) walk(child);
+    for (const child of node.floating_nodes || []) walk(child);
+  })(tree);
+  if (!found) throw new Error(`No window matching "${windowMatch}" found in Sway's tree — is it running?`);
+  return found;
+}
+
+export function moveWindowToSlot(windowMatch, slotIndex) {
+  const id = findWindowId(windowMatch);
+  sway(`[con_id=${id}] move to workspace number ${slotIndex}`);
+  return id;
+}
+
+export function forceFullscreen(windowMatch) {
+  const id = findWindowId(windowMatch);
+  sway(`[con_id=${id}] fullscreen enable`);
+  return id;
+}
+
+export function raiseWindow(windowMatch) {
+  const id = findWindowId(windowMatch);
+  sway(`[con_id=${id}] focus`);
+  return id;
+}
+
+export function currentSlot() {
+  const workspaces = swayJson("get_workspaces");
+  const active = workspaces.find((w) => w.focused);
+  return active ? active.num : null;
+}

--- a/tools/glass-access/backends/wayland.mjs
+++ b/tools/glass-access/backends/wayland.mjs
@@ -1,0 +1,30 @@
+// wayland.mjs — NOT YET IMPLEMENTED.
+//
+// Deliberately a stub, not a guess. Real research (2026-08-13, see the
+// project_wayland_display_control memory) found no single universal
+// tool — Wayland's window-management/input story is fragmented per
+// compositor:
+//   - wlrctl / wdotool for wlroots-based compositors (Sway, Hyprland,
+//     river, Wayfire), via wlr-foreign-toplevel-management
+//   - kdotool for KDE (KWin scripting)
+//   - swaymsg for Sway specifically
+//   - hyprctl for Hyprland specifically
+//   - underlying cross-compositor mechanism for most of this: the XDG
+//     RemoteDesktop portal + libei
+//
+// Per spencer, 2026-08-13: "the metal is mine and I will have
+// claude@nuc-1 direct that" — which machine/compositor this targets is
+// an infrastructure decision that arrives as a directive from nuc-1's
+// session, not something touchy's session should guess. Implement the
+// real functions below (matching x11.mjs's exact interface, so
+// glass-access.mjs doesn't change) once that's known.
+
+const NOT_CONFIGURED = "Wayland backend not implemented — target machine/compositor not yet confirmed by nuc-1. See project_wayland_display_control memory.";
+
+export function switchToSlot() { throw new Error(NOT_CONFIGURED); }
+export function wakeDisplay() { throw new Error(NOT_CONFIGURED); }
+export function findWindowId() { throw new Error(NOT_CONFIGURED); }
+export function moveWindowToSlot() { throw new Error(NOT_CONFIGURED); }
+export function forceFullscreen() { throw new Error(NOT_CONFIGURED); }
+export function raiseWindow() { throw new Error(NOT_CONFIGURED); }
+export function currentSlot() { throw new Error(NOT_CONFIGURED); }

--- a/tools/glass-access/backends/x11.mjs
+++ b/tools/glass-access/backends/x11.mjs
@@ -1,0 +1,53 @@
+// x11.mjs — the real, working backend for touchy (Cinnamon/X11).
+// Wraps the same wmctrl/xprop calls proven out manually this session
+// (workspace switch, move-window-to-workspace, force-fullscreen,
+// DPMS wake) behind a stable interface a Wayland backend can mirror
+// later without the CLI or config format needing to change.
+import { execSync } from "child_process";
+
+function sh(cmd) {
+  return execSync(`DISPLAY=:0 ${cmd}`, { encoding: "utf8" }).trim();
+}
+
+export function switchToSlot(slotIndex) {
+  sh(`wmctrl -s ${slotIndex}`);
+}
+
+export function wakeDisplay() {
+  sh(`xset dpms force on`);
+  sh(`xset s reset`);
+}
+
+export function findWindowId(windowMatch) {
+  const lines = sh(`wmctrl -l -x`).split("\n");
+  const hit = lines.find((l) => l.includes(windowMatch));
+  return hit ? hit.split(/\s+/)[0] : null;
+}
+
+export function moveWindowToSlot(windowMatch, slotIndex) {
+  const id = findWindowId(windowMatch);
+  if (!id) throw new Error(`No window matching "${windowMatch}" found — is it running?`);
+  sh(`wmctrl -i -r ${id} -t ${slotIndex}`);
+  return id;
+}
+
+export function forceFullscreen(windowMatch) {
+  const id = findWindowId(windowMatch);
+  if (!id) throw new Error(`No window matching "${windowMatch}" found — is it running?`);
+  sh(`wmctrl -i -r ${id} -b add,fullscreen`);
+  return id;
+}
+
+export function raiseWindow(windowMatch) {
+  const id = findWindowId(windowMatch);
+  if (!id) throw new Error(`No window matching "${windowMatch}" found — is it running?`);
+  sh(`wmctrl -i -a ${id}`);
+  return id;
+}
+
+export function currentSlot() {
+  // wmctrl -d marks the active desktop with "*" in column 2
+  const lines = sh(`wmctrl -d`).split("\n");
+  const active = lines.find((l) => l.includes("*"));
+  return active ? parseInt(active.trim()[0], 10) : null;
+}

--- a/tools/glass-access/config.dell-kiosk.json
+++ b/tools/glass-access/config.dell-kiosk.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Placeholder hostname — real machine identity not yet known, per direct instruction ('you can make the hostname anything you want... don't know don't care'). Real value: compositor (Sway) and role (all-in-one Dell touchscreen kiosk) are confirmed; slots/identities below are placeholders to be corrected once there's real access.",
+  "host": "dell-kiosk-1",
+  "backend": "wayland-sway",
+  "slots": {
+    "0": { "label": "Primary kiosk app", "windowMatch": "TBD" }
+  },
+  "identities": {
+    "touchy-claude": { "allowedSlots": ["0"], "note": "placeholder — cross-host identity, scope to be defined once real access exists" },
+    "spencer": { "allowedSlots": ["0"], "note": "full access" }
+  }
+}

--- a/tools/glass-access/config.json
+++ b/tools/glass-access/config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "identity -> which glass 'slots' (workspaces) it may control. Slot definitions are per-host; this file describes touchy's glass. A future host (Wayland) gets its own config with the same shape, once nuc-1 confirms the target machine/compositor.",
+  "host": "touchy",
+  "backend": "x11",
+  "slots": {
+    "0": { "label": "TCOS Dashboard", "windowMatch": "TCOS — AI Buildout Thesis" },
+    "1": { "label": "Home Assistant", "windowMatch": "Home Assistant" },
+    "2": { "label": "Playwright / Claude glass", "windowMatch": "Chromium" }
+  },
+  "identities": {
+    "claude-touchy": { "allowedSlots": ["2"], "note": "touchy's own Claude session — its own verification glass only, not the dashboard/HA slots a human normally drives" },
+    "spencer": { "allowedSlots": ["0", "1", "2"], "note": "full access, all slots" }
+  }
+}

--- a/tools/glass-access/glass-access.mjs
+++ b/tools/glass-access/glass-access.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// glass-access.mjs — access-controlled glass/slot switching.
+//
+// The point of this tool over bare wmctrl/kiosk-switch.sh: every action
+// checks a real identity -> allowed-slots mapping (config.json) BEFORE
+// touching the display, and the backend (x11 today, wayland once a
+// target machine is confirmed) is swappable without this file or the
+// config format changing. Direct ask, 2026-08-13: "a wayland control
+// utility that handles access rights to slots on the glass."
+//
+// Usage:
+//   node glass-access.mjs switch  --identity <id> --slot <n>
+//   node glass-access.mjs whoami  --identity <id>
+//   node glass-access.mjs status
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_FILE = process.env.GLASS_CONFIG || "config.json"; // e.g. GLASS_CONFIG=config.dell-kiosk.json
+const config = JSON.parse(fs.readFileSync(path.join(DIR, CONFIG_FILE), "utf8"));
+
+function parseArgs(argv) {
+  const [cmd, ...rest] = argv;
+  const opts = {};
+  for (let i = 0; i < rest.length; i += 2) opts[rest[i].replace(/^--/, "")] = rest[i + 1];
+  return { cmd, opts };
+}
+
+async function loadBackend() {
+  const mod = await import(`./backends/${config.backend}.mjs`);
+  return mod;
+}
+
+function checkAccess(identity, slot) {
+  const id = config.identities[identity];
+  if (!id) throw new Error(`Unknown identity "${identity}" — not in config.json's identities map.`);
+  if (!id.allowedSlots.includes(String(slot))) {
+    throw new Error(`Access denied: "${identity}" is not permitted on slot ${slot} (allowed: ${id.allowedSlots.join(", ")}).`);
+  }
+  const slotDef = config.slots[String(slot)];
+  if (!slotDef) throw new Error(`Unknown slot "${slot}" — not in config.json's slots map.`);
+  return slotDef;
+}
+
+async function main() {
+  const { cmd, opts } = parseArgs(process.argv.slice(2));
+
+  if (cmd === "status") {
+    const backend = await loadBackend();
+    console.log(`Host: ${config.host} (backend: ${config.backend})`);
+    console.log(`Current slot: ${backend.currentSlot()}`);
+    console.log(`Slots:`);
+    for (const [idx, def] of Object.entries(config.slots)) console.log(`  ${idx}: ${def.label}`);
+    return;
+  }
+
+  if (cmd === "whoami") {
+    const identity = config.identities[opts.identity];
+    if (!identity) throw new Error(`Unknown identity "${opts.identity}".`);
+    console.log(`${opts.identity}: allowed slots [${identity.allowedSlots.join(", ")}] — ${identity.note}`);
+    return;
+  }
+
+  if (cmd === "switch") {
+    if (!opts.identity || opts.slot === undefined) throw new Error("Usage: switch --identity <id> --slot <n>");
+    const slotDef = checkAccess(opts.identity, opts.slot);
+    const backend = await loadBackend();
+    backend.wakeDisplay();
+    backend.switchToSlot(opts.slot);
+    backend.raiseWindow(slotDef.windowMatch);
+    console.log(`OK: ${opts.identity} -> slot ${opts.slot} (${slotDef.label})`);
+    return;
+  }
+
+  console.error("Usage: glass-access.mjs {switch|whoami|status} [--identity <id>] [--slot <n>]");
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(`DENIED/ERROR: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Real permission layer for controlling display "slots" (workspaces) — identity checked against config before any action, not just bare window-manager commands
- X11 backend: real, tested live on touchy (status/whoami/switch, including a genuine permission denial)
- Sway backend: written against the confirmed target (all-in-one Dell kiosk, #193) but **untested** — no machine access yet
- `config.dell-kiosk.json` hostname is a placeholder per direct instruction, not a guess to be trusted

## Not done yet
- Live test against the real Dell kiosk once access exists
- Real slot/window definitions for that machine (currently placeholder)

Full context: #193