### PR TITLE
Register tick-task as a HEE consumer (backfill, already vendored)

### DIFF
--- a/docs/CONSUMERS.yaml
+++ b/docs/CONSUMERS.yaml
@@ -13,3 +13,7 @@ consumers:
     mode: vendored
     policy_version_path: docs/hee/VERSION.md
     vendor_tool: tooling/bin/hee-vendor
+  - repo: Twin-Cities-Open-Systems/tick-task
+    mode: vendored
+    policy_version_path: docs/hee/VERSION.md
+    vendor_tool: tooling/bin/hee-vendor


### PR DESCRIPTION
## Summary
- \`docs/doctrine/HEE.md\` opens with "this document defines the HEE model used by \`tick-task\`" -- but tick-task was never in \`docs/CONSUMERS.yaml\`.
- Confirmed live (not assumed) that tick-task is genuinely, fully vendored: real \`prompts/hee/\`, \`docs/hee/\`, \`docs/hee/VERSION.md\` tracking upstream commit \`d9330db60f4f098244eb5b6b084142c23d40f1c0\`, \`scripts/hee-check.sh\` installed.
- This backfills the registration using the same format as the existing entry.

## Why now, and why this isn't a HEE-to-TCOS tie

Real discussion, same day: HEE deliberately keeps no ties to TCOS (human-execution-engine#207). tick-task is TCOS-owned today, so directly hardcoding it in felt wrong at first -- resolved by treating this as **consumer-initiated registration**, the same mechanism any external consumer uses to add itself to the published list, not HEE depending on or referencing TCOS as part of its own design. tick-task already opted in by vendoring; this PR is just it showing up in the registry that says so.

## Test plan
- [x] Verified via GitHub API (not assumed) that tick-task's vendored structure is real and complete before drafting this entry