### PR TITLE
Fix governance.yaml fixture paths (fixes #199)

### DIFF
--- a/.github/workflows/governance.yaml
+++ b/.github/workflows/governance.yaml
@@ -81,7 +81,7 @@ jobs:
       run: |
         echo "🔍 Testing fixture: ok-minimal (expected: PASS)...TODO(spencer) convert to script"
         set +e
-        output="$(bash ci/governance/check.sh --path governance/fixtures/ok-minimal 2>&1)"
+        output="$(bash ci/governance/check.sh --path hee/governance/fixtures/ok-minimal 2>&1)"
         exit_code=$?
         set -e
 
@@ -119,7 +119,7 @@ jobs:
       run: |
         echo "🔍 Testing fixture: bad-missing-doctrine-doc (expected: FAIL with GOV-STRUCT-001, GOV-DOC-001)...TODO(spencer) convert to script"
         set +e
-        output="$(bash ci/governance/check.sh --path governance/fixtures/bad-missing-doctrine-doc 2>&1)"
+        output="$(bash ci/governance/check.sh --path hee/governance/fixtures/bad-missing-doctrine-doc 2>&1)"
         exit_code=$?
         set -e
 


### PR DESCRIPTION
Applies the fix already diagnosed in #199 -- two of four fixture-test
steps in `.github/workflows/governance.yaml` were missing the `hee/`
prefix on their fixture path, causing every run to fail with
`ERROR: Failed to resolve path:` regardless of the PR's actual content.
Caught live failing again on run #235 today, root cause unchanged from
the original diagnosis. Not a CODEOWNERS-gated path.

Closes #199.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>