### PR TITLE
fix: add canonical path headers to 21 contracts/blueprints files

### DIFF
--- a/blueprints/dir-layout-v1.yaml
+++ b/blueprints/dir-layout-v1.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/dir-layout-v1.yaml
 apiVersion: hee/v1
 kind: BlueprintDoctrine
 metadata:

--- a/blueprints/doctrine/blueprint-doctrine.yaml
+++ b/blueprints/doctrine/blueprint-doctrine.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/doctrine/blueprint-doctrine.yaml
 blueprint:
   name: blueprint-doctrine
   schema-version: 2

--- a/blueprints/doctrine/core-tools-doctrine.yaml
+++ b/blueprints/doctrine/core-tools-doctrine.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/doctrine/core-tools-doctrine.yaml
 blueprint:
   name: core-tools-doctrine
   schema-version: 1

--- a/blueprints/doctrine/hee-doctrine.yaml
+++ b/blueprints/doctrine/hee-doctrine.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/doctrine/hee-doctrine.yaml
 
 identity:
   seed: hee-doctrine

--- a/blueprints/doctrine_snapshot_v0.yaml
+++ b/blueprints/doctrine_snapshot_v0.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/doctrine_snapshot_v0.yaml
 spec_version: 2
 name: HEE-Heavy-Doctrine
 description: Human Execution Engine Heavy Doctrine

--- a/blueprints/gitops-coordination-v1.yaml
+++ b/blueprints/gitops-coordination-v1.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/gitops-coordination-v1.yaml
 apiVersion: hee/v1
 kind: BlueprintDoctrine
 metadata:

--- a/blueprints/hee_squeeze_citation_strip_v0.yaml
+++ b/blueprints/hee_squeeze_citation_strip_v0.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/hee_squeeze_citation_strip_v0.yaml
 version: 1.0
 name: HEE-Squeeze-Citation-Strip
 description: Human Execution Engine Citation Stripping Component

--- a/blueprints/hee_traverse_proto_v0.yaml
+++ b/blueprints/hee_traverse_proto_v0.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/hee_traverse_proto_v0.yaml
 version: 1.0
 name: HEE-Traverse-Proto
 description: Human Execution Engine Traverse Protocol

--- a/blueprints/hee_words_seed_stub.yaml
+++ b/blueprints/hee_words_seed_stub.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/hee_words_seed_stub.yaml
 version: 1.0
 name: HEE-Words-Seed-Stub
 description: Human Execution Engine Words Seed Stub

--- a/blueprints/hiring-handshake-v1.yaml
+++ b/blueprints/hiring-handshake-v1.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/hiring-handshake-v1.yaml
 apiVersion: hee/v1
 kind: BlueprintDoctrine
 metadata:

--- a/blueprints/human_v0.yaml
+++ b/blueprints/human_v0.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/human_v0.yaml
 version: 1.0
 name: HEE-Human
 description: Human Execution Engine Human Component

--- a/blueprints/index.yaml
+++ b/blueprints/index.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/index.yaml
 version: 1.0
 name: HEE-Relay-Office-Index
 description: Minimal index for relay-office snapshot pills

--- a/blueprints/plan/plan-create.blueprint.yaml
+++ b/blueprints/plan/plan-create.blueprint.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/plan/plan-create.blueprint.yaml
 # blueprints/plan/plan-create.blueprint.yaml
 
 apiVersion: hee/v1

--- a/blueprints/prio_interrogator_v0.yaml
+++ b/blueprints/prio_interrogator_v0.yaml
@@ -1,3 +1,4 @@
+# path: blueprints/prio_interrogator_v0.yaml
 version: 1.0
 name: HEE-Prio-Interrogator
 description: Priority Interrogator for Human Execution Engine

--- a/contracts/chat-header-v1.doctrine.yaml
+++ b/contracts/chat-header-v1.doctrine.yaml
@@ -1,3 +1,4 @@
+# path: contracts/chat-header-v1.doctrine.yaml
 
 identity:
   seed: chat-header

--- a/contracts/dric-v1.contract.yaml
+++ b/contracts/dric-v1.contract.yaml
@@ -1,3 +1,4 @@
+# path: contracts/dric-v1.contract.yaml
 version: dric-v1.01
 name: dric
 title: Design–Relay Interface Contract (DRIC-v1)

--- a/contracts/hee-schema-id-v1.contract.yaml
+++ b/contracts/hee-schema-id-v1.contract.yaml
@@ -1,3 +1,4 @@
+# path: contracts/hee-schema-id-v1.contract.yaml
 version: hee-schema-id-v1
 name: hee-schema-id
 title: HEE Schema ID Contract (v1)

--- a/contracts/hee-sqz-roll-v1.contract.yaml
+++ b/contracts/hee-sqz-roll-v1.contract.yaml
@@ -1,3 +1,4 @@
+# path: contracts/hee-sqz-roll-v1.contract.yaml
 version: hee-sqz-roll-v1
 name: hee-sqz-roll
 title: HEE SQZ Roll Contract (v1)

--- a/contracts/outfile-evidence-v1.contract.yaml
+++ b/contracts/outfile-evidence-v1.contract.yaml
@@ -1,3 +1,4 @@
+# path: contracts/outfile-evidence-v1.contract.yaml
 version: outfile-evidence-v1
 name: outfile-evidence
 title: GPT–Oper Outfile Evidence Contract

--- a/contracts/roles-trilateral-v1.contract.yaml
+++ b/contracts/roles-trilateral-v1.contract.yaml
@@ -1,3 +1,4 @@
+# path: contracts/roles-trilateral-v1.contract.yaml
 version: roles-trilateral-v1
 name: roles-trilateral
 title: GPT–Oper–Agent Roles Contract

--- a/contracts/validator-contract-v1.contract.yaml
+++ b/contracts/validator-contract-v1.contract.yaml
@@ -1,3 +1,4 @@
+# path: contracts/validator-contract-v1.contract.yaml
 
 blueprint:
   name: validator-contract-doctrine


### PR DESCRIPTION
Closes [human-execution-engine#227](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/issues/227). Ran the repo's own `ci/naming/fix_yaml_path_header.py --apply` (real autofix mode, not hand-edited) — one `# path: ...` header line inserted per file, nothing else touched. Verified: `--check` passes clean, every touched file still parses as valid YAML.

**Found while verifying end-to-end, not fixed here**: a *third* naming check (`ci/naming/check_authoritative_yaml_naming.py`, kebab-case enforcement) fails on these same files plus more — its rule (`^[a-z0-9-]+$` after stripping `.yaml`, no dots allowed) directly conflicts with the repo's own established `*.contract.yaml`/`*.doctrine.yaml`/`*.blueprint.yaml` naming convention, which encodes artifact type in the filename on purpose. This isn't a typo to autofix — it's either the checker's rule that's wrong, or a real repo-wide rename across dozens of files (including already-merged ones referenced elsewhere, like `contracts/shift-schedule-v1.contract.yaml`). Not touching it without a decision — reported separately, not filed as its own issue yet pending your call on which direction is correct.