### PR TITLE
Add agent-instance-signature-v1 contract + tools/agent-signature.sh

### DIFF
--- a/contracts/agent-instance-signature-v1.contract.yaml
+++ b/contracts/agent-instance-signature-v1.contract.yaml
@@ -1,0 +1,87 @@
+# path: contracts/agent-instance-signature-v1.contract.yaml
+version: agent-instance-signature-v1
+name: agent-instance-signature
+title: Agent Instance Signature Contract
+status: proposed
+
+intent:
+  - "make every inter-agent message and every agent-authored public post
+    (GitHub issue/PR comment) traceable to one specific running process,
+    not just to a shared identity name"
+  - "solve a real incident, not a hypothetical: 2026-08-18, kiosk had two
+    concurrent processes both authenticated as touchy-claude (fleet-ops#182
+    tmux `kiosk` and `agent` sessions), one posting a correction to
+    fleet-ops#182 while a second, unrelated one asserted PR#132 was
+    'merged and deployed' when it was still open -- neither claim carried
+    anything identifying which process made it"
+  - "reuse the fleet's existing UUID mechanism (hee.kind-registry's
+    metadata.annotations.inuid, contracts/hee.kind-registry.contract.v1.yaml)
+    rather than inventing a new one -- Claude Code already assigns a real
+    UUID per running instance (env: CLAUDE_CODE_SESSION_ID), so the
+    'new' mechanism this contract needs is zero new infrastructure: read
+    what's already there and require it to be shown"
+
+actors:
+  identity:
+    must:
+      - "on any SendMessage / cross-session message, include the signature
+        block defined below"
+      - "on any GitHub issue/PR comment posted by an agent, append the
+        signature block as a trailing footer"
+      - "if a field is genuinely unavailable (e.g. not running inside
+        tmux), state that explicitly (tmux_uri: none) rather than
+        omitting the field silently"
+    must_not:
+      - "fabricate or guess a signature field it did not actually read
+        from its own environment"
+      - "reuse another instance's signature fields as if they were its own"
+
+boundaries:
+  governs: "inter-agent SendMessage traffic and agent-authored GitHub comments"
+  does_not_govern: "git commit authorship (already covered by docs/guides/GIT_GH_WORKFLOW.md) or file-level HEE-object identity (already covered by inuid, contracts/hee.kind-registry.contract.v1.yaml)"
+
+signature-block:
+  description: >
+    Every field is read directly from the running process's own
+    environment or from a cheap local command -- nothing here is
+    invented or centrally issued. tools/agent-signature.sh prints this
+    block; use it instead of hand-assembling the fields.
+  fields:
+    session_id:
+      source: "env CLAUDE_CODE_SESSION_ID"
+      notes: "the real per-instance UUID -- functionally the same kind
+        of identifier as inuid, just for a live process instead of a
+        static YAML file"
+    pid:
+      source: "env CLAUDE_PID (falls back to $$ if unset)"
+    tmux_uri:
+      source: "env TMUX + TMUX_SESSION + TMUX_PANE, formatted
+        '<socket_path>:<session>:<pane>'"
+      notes: "'none' if not running inside tmux. 2026-08-18's kiosk
+        incident included a session on a tmux socket opened with -S ''
+        (empty string) -- report the raw socket path exactly as found,
+        including if it's empty, rather than normalizing it away"
+    messaging_socket:
+      source: "env CLAUDE_CODE_MESSAGING_SOCKET"
+      notes: "this is the literal address a peer would use to
+        SendMessage this instance -- the strongest single disambiguator
+        available"
+    host:
+      source: "hostname"
+    gh_actor:
+      source: "gh auth status (active account)"
+    timestamp:
+      source: "date -Is"
+
+validation:
+  status: "not CI-enforced -- proposed doctrine only, same honesty
+    requirement as prompts/INIT.md's own hash-chain caveat and the
+    known-unenforced git-wrapper gap on fleet-ops#173/docs/guides/GIT_GH_WORKFLOW.md.
+    Don't claim this is checked until something actually checks it."
+
+extension-path:
+  - "if a stronger identifier is ever needed (e.g. cryptographic signing
+    of comments), extend this contract's signature-block rather than
+    starting a third parallel identity scheme -- the fleet already has
+    two (inuid for files, CLAUDE_CODE_SESSION_ID for processes); a third
+    would recreate the exact ambiguity this contract exists to remove"

--- a/scripts/hee_git_ops.sh
+++ b/scripts/hee_git_ops.sh
@@ -29,7 +29,7 @@ is_protected_branch() {
   [[ "$b" == "main" || "$b" == "master" ]]
 }
 
-require_liveness_for_mutation() {
+require_liveness() {
   local act_flag="${1:-}"
   local mode="${HEE_TOOL_MODE:-}"
   if [[ "$act_flag" != "1" ]]; then
@@ -38,6 +38,10 @@ require_liveness_for_mutation() {
   if [[ "$mode" != "ACT" ]]; then
     blocker "Mutation requested but HEE_TOOL_MODE!=ACT (got: '${mode:-<unset>}'). Refusing."
   fi
+}
+
+require_liveness_for_mutation() {
+  require_liveness "${1:-}"
   if is_protected_branch; then
     blocker "Mutation requested on protected branch '$(current_branch)'. Refusing."
   fi
@@ -183,14 +187,24 @@ git commit "$@"
     ;;
 
   checkout)
-    # checkout can be read-only-ish, but it mutates HEAD; treat as mutation.
-    require_liveness_for_mutation "$act"
+    # Same reasoning as branch-create: the thing actually worth blocking
+    # is committing/pushing *while on* main, not leaving main to go work
+    # on a branch -- gating checkout on the *current* (pre-checkout)
+    # branch made it impossible to ever check out away from main, which
+    # is the one time this op is actually needed. commit/push below still
+    # fully enforce the real protection.
+    require_liveness "$act"
     [[ $# -eq 1 ]] || die "checkout requires <branch>"
     git checkout "$1"
     ;;
 
   branch-create)
-    require_liveness_for_mutation "$act"
+    # Deliberately not require_liveness_for_mutation: `git branch <name>`
+    # from main doesn't touch main or move HEAD, and main is the only
+    # place you'd ever actually call this from -- the protected-branch
+    # gate made this op impossible to use for its own purpose. Found
+    # 2026-08-18 on first real use (contracts/agent-instance-signature-v1).
+    require_liveness "$act"
     [[ $# -eq 1 ]] || die "branch-create requires <name>"
     git branch "$1"
     ;;

--- a/tools/agent-signature.sh
+++ b/tools/agent-signature.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# path: tools/agent-signature.sh
+# Prints the signature block defined by
+# contracts/agent-instance-signature-v1.contract.yaml -- every field is
+# read from this process's own environment, nothing invented or
+# centrally issued. Use this instead of hand-assembling the fields.
+#
+# Usage:
+#   tools/agent-signature.sh          # human-readable block
+#   tools/agent-signature.sh --footer # markdown footer for a GitHub comment
+set -euo pipefail
+
+session_id="${CLAUDE_CODE_SESSION_ID:-unknown}"
+pid="${CLAUDE_PID:-$$}"
+host="$(hostname)"
+ts="$(date -Is)"
+
+if [[ -n "${TMUX:-}" ]]; then
+  socket_path="${TMUX%%,*}"
+  tmux_uri="${socket_path}:${TMUX_SESSION:-unknown}:${TMUX_PANE:-unknown}"
+else
+  tmux_uri="none"
+fi
+
+msg_socket="${CLAUDE_CODE_MESSAGING_SOCKET:-none}"
+
+gh_actor="$(gh auth status 2>&1 | grep -oP 'account \K\S+' | head -1 || echo unknown)"
+
+if [[ "${1:-}" == "--footer" ]]; then
+  cat <<EOF
+
+---
+<sub>signed: session \`${session_id}\` · pid \`${pid}\` · tmux \`${tmux_uri}\` · ${gh_actor}@${host} · ${ts}</sub>
+EOF
+else
+  cat <<EOF
+session_id:        ${session_id}
+pid:                ${pid}
+tmux_uri:           ${tmux_uri}
+messaging_socket:   ${msg_socket}
+host:               ${host}
+gh_actor:           ${gh_actor}
+timestamp:          ${ts}
+EOF
+fi


### PR DESCRIPTION
Codifies today's (2026-08-18) real, live-verified fix for a real incident, per Spencer's direction to write it up as a contract rather than let it stay a one-off chat exchange.

## The incident

kiosk had two concurrent processes both authenticated as `touchy-claude` (see [fleet-ops#182](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/182)): this session posting a correction to that issue, while a second, unrelated session asserted PR#132 was "merged and deployed" when it was still open. Neither message carried anything identifying which specific process made it. Resolved live via `SendMessage` + `tmux capture-pane` (two peer sessions found each other, split ownership of overlapping work, no collision) — but nothing forced that to happen; it worked because we happened to notice.

## What this adds

- `contracts/agent-instance-signature-v1.contract.yaml` — requires inter-agent messages and agent-authored GitHub comments to carry a signature block (session UUID, pid, tmux URI, messaging socket, host, gh actor, timestamp), scoped explicitly to *not* duplicate git-commit authorship (already covered) or file-level `inuid` (already covered).
- `tools/agent-signature.sh` — prints that block. Every field comes straight out of the running process's own environment (`CLAUDE_CODE_SESSION_ID`, `CLAUDE_PID`, `TMUX*`, `CLAUDE_CODE_MESSAGING_SOCKET`) or a cheap local command (`hostname`, `gh auth status`). No new ID scheme, no registry, no central issuance — reuses the same "real UUID per instance" idea `inuid` already uses for static files, just for a live process. Tested against this session's own real values.

**Honest status**: `status: proposed`, not CI-enforced — same as `shift-schedule-v1`/`shift-metrics-v1`. Not claiming this is checked until something actually checks it.

## Also included: a real bug fix, found using this contract for the first time

`scripts/hee_git_ops.sh`'s `branch-create` and `checkout` were gated by the same protected-branch check as `commit`/`push` — which made it impossible to ever create or check out a branch while starting from `main`, the one time either op is actually needed. This is the first PR in this repo to go through `hee_git_ops.sh --act` end-to-end for real (per `prompts/INIT.md` item 4, previously flagged as never-actually-followed on [fleet-ops#173](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/173)), and hit this immediately. Fixed by splitting the act/mode check (`require_liveness`) from the protected-branch check (`require_liveness_for_mutation`); `commit`/`push`'s actual protection is untouched and re-verified working (attempted a commit on `main`, correctly blocked).

## Not done here

- Not wiring this into CI (no enforcement mechanism proposed yet — would need a hook on comment-posting, which doesn't exist).
- Not touching the pre-existing kebab-case naming-checker conflict (`ci/naming/check_authoritative_yaml_naming.py` flags this file's name the same way it already flags every other `*.contract.yaml` file — known, unresolved, out of scope here per the 2026-08-18 shift report).