### PR TITLE
hee/docs: BTC energy/time spread Thesis

### DIFF
--- a/hee/docs/btc-energy-time-spread.md
+++ b/hee/docs/btc-energy-time-spread.md
@@ -1,0 +1,48 @@
+# Thesis
+
+Per Spencer, 2026-08-18, following directly from a separate thesis on
+conservation of energy (Noether's theorem, time-translation symmetry —
+energy conservation is structurally necessary, not just empirically
+untested-against). His words, cleaned up but not softened:
+
+BTC is a long con, and not the one the popular narrative describes —
+it was never really about "the banks, the blabla" (decentralization as
+rebellion against monetary authority). The real story is energy and the
+US dollar, same as it always is. BTC reduces to **energy and time**:
+proof-of-work is, structurally, a mechanism for converting energy
+expenditure over time into a scarce, transferable asset. Whoever has
+access to **cheap energy and a long time horizon has a structural
+spread** — the same shape as any other arbitrage: buy the input cheap
+relative to what the output is worth, and be patient enough not to need
+to unwind the position on someone else's timeline.
+
+## Follow-up
+
+Testable implications worth naming, not yet checked here:
+
+- If the thesis is right, large-scale BTC mining operations should
+  concentrate wherever energy is genuinely cheap/stranded/otherwise
+  hard to monetize (hydro overcapacity, flared associated gas, off-peak
+  grid curtailment) rather than being geographically random. This is a
+  real, checkable pattern against actual mining-hashrate-by-region data
+  — not verified in this doc, a real next step if this thesis gets
+  taken further.
+- "Long time is a spread" implies the edge specifically belongs to
+  patient capital that doesn't need to liquidate on a short clock —
+  i.e. the same operator mining through a drawdown has a structural
+  advantage over one forced to sell into it. Checkable against real
+  miner-capitulation events during past drawdowns (do the operators who
+  survive skew toward cheap-energy access, or toward something else —
+  balance sheet size, hedging, etc.)?
+- The USD/oil framing specifically (as opposed to USD/energy broadly)
+  isn't yet argued for here — worth Spencer's own follow-up on why oil
+  specifically, versus energy as a general category, if that
+  distinction is load-bearing to the thesis or just the framing he
+  reached for.
+
+Not yet connected here, but adjacent: this is exactly the kind of
+market thesis `thesis-engine` (per its own `CLAUDE.md`, "general-purpose
+thesis test/monitor/model/confirm framework," markets as module one) is
+built to actually test against real data, not just hold as a belief —
+worth deciding whether this belongs there as a real tracked thesis, not
+just a HEE doc.


### PR DESCRIPTION
Per Spencer, 2026-08-18, following the conservation-of-energy Thesis from earlier the same conversation. Real, testable implications in the Follow-up section, explicitly not verified here — flagged as next steps (mining-region concentration vs. energy cost, patient-capital survival through drawdowns), not claimed as checked.

Doesn't regenerate `docs/THESIS_INDEX.md` — [`tools/hee-thesis-index.py`](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/pull/234) isn't on `main` yet. Index will pick this doc up once that merges.