### PR TITLE
remove brain dead ci check steps

### DIFF
--- a/.github/workflows/hee-preflight.yaml
+++ b/.github/workflows/hee-preflight.yaml
@@ -12,10 +12,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Ensure local main exists
-        run: git fetch origin +refs/heads/main:refs/remotes/origin/main
-      - name: Ensure local main branch exists
-        run: git branch -f main origin/main
+          ref: main # explicity main checkout
       - name: Install required tools
         run: |
           sudo apt-get update


### PR DESCRIPTION
# 🎯 Purpose

failing CI test because it was trying to force checkout main.

## 📦 Scope

just a silly test. @touchy-claude we need to audit our entire CI workflow

- Change type:
  - [x] fix
  - [ ] feature
  - [ ] contract
  - [ ] docs
  - [ ] refactor
  - [ ] governance

