### PR TITLE
docs(policy): only the opener closes/merges their own ticket or PR

### DIFF
--- a/docs/doctrine/HEE_POLICY.md
+++ b/docs/doctrine/HEE_POLICY.md
@@ -300,6 +300,22 @@ reason it doesn't
   blocked on a decision, needs triage)
 - Close tickets as soon as their work is actually done — don't let
   finished or stale work sit open
+- **Only whoever opened a ticket or PR closes/merges it.** Real sysadmin
+  practice, not HEE-invented: it's a guard against the opener's own
+  reviewer clicking through too fast, not a judgment on the work itself
+  — approving is not the same act as merging, and reviewing everything
+  in bulk (the normal mode when a human is behind on review) makes an
+  accidental merge easy without this. This is a **default, not an
+  absolute** — deviate freely with an **explicit** exception from the
+  opener in the moment ("go ahead and merge/close this one"), never
+  inferred from silence, a prior approval, or "they'll probably want
+  this merged." An agent's own work is closed/merged by the human who
+  requested it or by the agent that opened it, never by a different
+  agent filling in. Prompted by
+  [`human-execution-engine#249`](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/pull/249#pullrequestreview-4996249864) —
+  Spencer approved but deliberately didn't merge his own contracted
+  agent's PR, precisely because review-approval and having-read-every-line
+  aren't the same thing, and merge authority should track the latter.
 
 **Known platform constraint: GitHub blocks self-approval, always**
 

--- a/prompts/PROMPTING_RULES.md
+++ b/prompts/PROMPTING_RULES.md
@@ -21,7 +21,9 @@ the top of a session, per `prompts/INIT.md`.
    Policy §5. Structured work files (contracts/blueprints/doctrine YAML)
    use the compact `tick:N@repo`/`pr:N@repo` notation instead — §13.
 4. **Self-assign what you create, label from the existing set, never
-   invent a new label** — HEE Policy §10/§12.
+   invent a new label. Only the opener closes/merges their own ticket
+   or PR** — explicit exception only, never inferred — **HEE Policy
+   §10/§12.**
 5. **When in doubt, stop and ask rather than guess** — same invariant as
    below, restated because it's the one that matters most.
 


### PR DESCRIPTION
New HEE Policy §10 enforcement bullet: only whoever opened a ticket/PR closes/merges it, by default -- explicit exception from the opener always overrides, silence/prior-approval does not.

Prompted directly by Spencer's review on [human-execution-engine#249](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/pull/249#pullrequestreview-4996249864): he approved but deliberately didn't squash-merge his own contracted agent's PR, because "there is implicit trust with my contracted agents" but approving after reading everything and merging after reading everything aren't the same act.

Also self-assigns to this: I already follow this in practice (never merge my own PRs, always add Spencer as reviewer) -- this makes it written policy instead of an unstated convention I happen to follow.