### PR TITLE
docs(policy): Canonization Policy -- reconcile doctrine-vs-practice drift, don't paper over it

### DIFF
--- a/docs/doctrine/HEE_POLICY.md
+++ b/docs/doctrine/HEE_POLICY.md
@@ -416,6 +416,60 @@ not a link.
   retrofitted across the rest of the repo, tracked as future cleanup, not
   claimed as done everywhere
 
+### 14. Canonization Policy (doctrine-vs-practice drift)
+
+**Requirement**: when stated documentation and actual real precedent
+contradict each other, the contradiction gets surfaced and reconciled
+through a real procedure — never silently papered over by picking one
+side, and never left standing as an unremarked contradiction
+
+**Rationale**: fast-moving, high-level concept work outruns its own
+documentation as a matter of course, not as a failure — a design
+principle gets written down, then real practice (a recovered legacy
+script, a pragmatic workaround, a decision made in chat and never
+back-filled into the doc) diverges from it before anyone revisits the
+page. Left alone, this produces exactly the failure mode found
+2026-08-21: `glass-browser/README.md` stated "no password flow exists
+anywhere in this repo, on purpose," while `do-login.mjs` — a real,
+already-in-use scripted password flow, recovered from an earlier
+identity 2026-08-16 — sat right next to it, undocumented and
+uncontradicted-in-the-open. Neither the old doc nor the new practice
+was wrong to have existed; the drift between them just never got
+resolved.
+
+**Enforcement — the actual procedure, Spencer's own framing**:
+
+1. **Surface the tension explicitly, don't pick a side quietly.** State
+   both what the doc says and what practice actually does, as a real
+   named contradiction — not "the doc is outdated" (presumes the doc
+   loses) and not silently following whichever one the current task
+   happens to need (presumes practice wins by default).
+2. **Review both the old standard's reasoning and current practice's
+   reasoning.** The old doc's principle existed for a real reason
+   (here: minimizing where credentials could leak); so did the
+   departure from it (here: Xwayland/xdotool synthetic input proved
+   unreliable enough that a real Playwright-driven login flow was
+   worth building). Understand why each side exists before choosing
+   between them.
+3. **Reason toward the best of both, not a unilateral pick.** The
+   resolution doesn't have to be "old wins" or "new wins" — it can (and
+   often should) preserve what made the old principle sound while
+   adopting what made the new practice necessary. The glass-browser
+   resolution keeps the old boundary that ongoing *task* files never
+   touch credentials, while adopting the new pattern that *bootstrap*
+   scripts are the sanctioned, scripted way a session gets established
+   in the first place.
+4. **The human makes the actual call when it's a real decision, not a
+   mechanical fix.** Present the reconciliation options plainly;
+   don't resolve a genuine design tradeoff unilaterally just because a
+   plausible synthesis exists.
+5. **Canonize and move on.** Update the doc to state the resolved rule,
+   dated and attributed, with enough of the reasoning kept that a
+   future re-read of the doc explains itself rather than reading as an
+   arbitrary decree. Then the tension is closed — this isn't a standing
+   review process to revisit, it's a one-time reconciliation per drift
+   found.
+
 ### HEE Rule Violation Documentation
 
 **Process**:

--- a/prompts/PROMPTING_RULES.md
+++ b/prompts/PROMPTING_RULES.md
@@ -24,6 +24,13 @@ the top of a session, per `prompts/INIT.md`.
    invent a new label** — HEE Policy §10/§12.
 5. **When in doubt, stop and ask rather than guess** — same invariant as
    below, restated because it's the one that matters most.
+6. **When a doc's stated design contradicts real precedent already in
+   use, surface both sides and reconcile — don't silently pick one.**
+   Review why the old standard existed and why current practice
+   diverged, reason toward the best of both rather than a unilateral
+   pick, let the human decide on a genuine tradeoff, then canonize the
+   resolution back into the doc with its reasoning kept — HEE Policy
+   §14.
 
 ## Authority Invariants
 


### PR DESCRIPTION
New HEE Policy §14. Your framing from chat, made into a real procedure rather than left as an ad hoc thing I apply when I happen to notice drift: surface both sides of a doc-vs-practice contradiction explicitly, review why each existed, reason toward the best of both rather than a unilateral pick, let you decide the genuine tradeoff, canonize the resolution with its reasoning kept.

Grounded in the real case that prompted this: [glass-ops#6](https://github.com/Twin-Cities-Open-Systems/glass-ops/pull/6)'s README said "no password flow exists anywhere in this repo, on purpose" while `do-login.mjs` -- a real scripted password flow, recovered from an earlier identity -- sat right there undocumented. That PR's fix is the worked example this policy points back to.