### PR TITLE
feat(tooling): hee-stat -- stat(1)'s interface, applied to namespaced resources

### DIFF
--- a/examples/hee-stat-output.md
+++ b/examples/hee-stat-output.md
@@ -1,0 +1,56 @@
+# `hee-stat` — real run
+
+Real trigger, 2026-08-21: Spencer's `./hee stat -c %REPO gh/spencerbutler`.
+`stat(1)`'s interface convention (`-c FORMAT`), applied to a namespaced
+resource (`gh/...`) instead of the filesystem — not a fork of GNU
+coreutils' `stat.c`, a new `hee` subcommand reusing the same mental
+model.
+
+## The exact invocation that started this
+
+```
+$ ./hee stat -c %REPO gh/spencerbutler
+(empty line)
+```
+
+Correct, not a bug: `gh/spencerbutler` is a **user** path (no repo
+component), so `%REPO` legitimately has nothing to show. Confirmed
+deliberately, not assumed:
+
+```
+$ ./hee stat -c "[%REPO]" gh/spencerbutler
+[]
+```
+
+## Real stat(1) semantics, reused rather than reinvented
+
+```
+$ ./hee stat -c "n=%n U=%U W=%W Y=%Y s=%s" gh/spencerbutler
+n=spencerbutler U=spencerbutler W=1375241892 Y=1787184337 s=13
+
+$ TZ=GMT date -d @1375241892
+Wed Jul 31 03:38:12 AM GMT 2013   # real GitHub account creation date
+
+$ TZ=GMT date -d @1787184337
+Thu Aug 20 12:05:37 AM GMT 2026   # real last-activity date
+```
+
+`%W` (birth time) and `%Y` (mtime) are `stat`'s own real specifiers,
+carrying the same semantic meaning here as they do on a real file —
+just answering "when was this GitHub identity created / last active"
+instead of "when was this file created / last modified."
+
+## A real repo, using the TCOS convenience aliases
+
+```
+$ ./hee stat -c "n=%n REPO=%REPO ORG=%ORG W=%W" gh/Twin-Cities-Open-Systems/primitives
+n=Twin-Cities-Open-Systems/primitives REPO=primitives ORG=Twin-Cities-Open-Systems W=1787338054
+```
+
+## Open, not yet built
+
+Only the `gh/` namespace exists. Spencer's own framing was "explore
+forking for our purposes" more broadly — other namespaces (`fs/` for
+real filesystem passthrough through the same `-c FORMAT` interface,
+maybe others) could follow the same pattern once there's a real second
+use case, not built speculatively here.

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -14,3 +14,9 @@ Tools:
 - tooling/bin/hee-attach  : attach doctrine locally without committing it (detached mode)
 - tooling/bin/hee-sync-cursor-prompts : derive .cursor/prompts from the active policy source
 - tooling/bin/hee-check   : boundary/compliance checks
+- tooling/bin/hee-stat    : stat(1)'s `-c FORMAT` interface, applied to namespaced
+  resources instead of the filesystem -- `hee stat -c %W gh/OWNER/REPO` for a repo's
+  real creation epoch, same convention as `stat -c %W somefile`. First namespace: `gh/`
+  (GitHub users/repos, via `gh api`). Real specifiers reuse `stat`'s actual semantics
+  (`%W`=birth time, `%Y`=mtime, `%U`=owner, `%n`=name) plus two TCOS convenience
+  aliases (`%REPO`, `%ORG`). See `examples/hee-stat-output.md`.

--- a/tooling/bin/hee-stat
+++ b/tooling/bin/hee-stat
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""hee-stat -- stat(1)'s interface convention, applied to namespaced
+resources instead of the filesystem.
+
+Real trigger (2026-08-21): Spencer's "./hee stat -c %REPO gh/spencerbutler"
+-- not a fork of GNU coreutils' stat.c (see primitives#4's original
+framing, which this supersedes), a NEW hee subcommand that reuses
+stat's familiar -c FORMAT convention over a namespaced path instead of
+a filesystem path. First namespace: gh/ (GitHub). Others (fs/ for real
+filesystem passthrough, x/ for the X account, etc.) can follow the same
+pattern once there's a real second use case -- not built speculatively
+here.
+
+Real stat(1) semantics reused where they map naturally, not reinvented:
+  %n  name (full gh/... path)
+  %U  owner/org login
+  %W  creation time (stat's real "birth time" -- created_at, Unix epoch)
+  %Y  last-updated time (stat's real "mtime" -- pushed_at/updated_at, Unix epoch)
+  %s  size (repo size in KB, or a user's public repo count)
+Convenience aliases, matching Spencer's own invented syntax directly:
+  %REPO   repo name (empty for a user path)
+  %ORG    owner/org login (alias of %U)
+
+Usage:
+  hee-stat -c FORMAT gh/OWNER          # a GitHub user/org
+  hee-stat -c FORMAT gh/OWNER/REPO     # a GitHub repo
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def gh_json(*args):
+    out = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"hee-stat: gh api failed: {out.stderr.strip()}")
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        sys.exit(f"hee-stat: gh api returned non-JSON: {out.stdout[:200]}")
+
+
+def to_epoch(iso_ts):
+    if not iso_ts:
+        return ""
+    return str(int(datetime.fromisoformat(iso_ts.replace("Z", "+00:00")).timestamp()))
+
+
+def stat_gh(path: str) -> dict:
+    parts = path.split("/")
+    if len(parts) == 1:
+        owner = parts[0]
+        data = gh_json(f"users/{owner}")
+        return {
+            "n": owner,
+            "U": owner,
+            "W": to_epoch(data.get("created_at")),
+            "Y": to_epoch(data.get("updated_at")),
+            "s": str(data.get("public_repos", "")),
+            "REPO": "",
+            "ORG": owner,
+        }
+    elif len(parts) == 2:
+        owner, repo = parts
+        data = gh_json(f"repos/{owner}/{repo}")
+        return {
+            "n": f"{owner}/{repo}",
+            "U": owner,
+            "W": to_epoch(data.get("created_at")),
+            "Y": to_epoch(data.get("pushed_at") or data.get("updated_at")),
+            "s": str(data.get("size", "")),
+            "REPO": repo,
+            "ORG": owner,
+        }
+    else:
+        sys.exit(f"hee-stat: don't know how to stat '{path}' -- gh/OWNER or gh/OWNER/REPO only, for now")
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("-c", dest="fmt", required=True, metavar="FORMAT")
+    ap.add_argument("path")
+    args = ap.parse_args()
+
+    if not args.path.startswith("gh/"):
+        sys.exit(f"hee-stat: unknown namespace in '{args.path}' -- only gh/ exists so far")
+    ns_path = args.path[len("gh/"):]
+
+    fields = stat_gh(ns_path)
+
+    def repl(m):
+        key = m.group(1)
+        if key not in fields:
+            sys.exit(f"hee-stat: unknown format specifier %{key}")
+        return fields[key]
+
+    out = re.sub(r"%([A-Za-z]+)", repl, args.fmt)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Your real trigger: \`./hee stat -c %REPO gh/spencerbutler\`. Not a fork of GNU coreutils (supersedes that framing from [primitives#4](https://github.com/Twin-Cities-Open-Systems/primitives/issues/4)) -- a new \`hee\` subcommand reusing \`stat\`'s \`-c FORMAT\` convention over \`gh/...\` paths instead of the filesystem. Zero router changes needed -- \`tooling/bin/hee\` already dispatches unknown commands to \`tooling/bin/hee-<cmd>\`.

Real \`stat(1)\` specifiers reused where they map cleanly (\`%W\`=birth time, \`%Y\`=mtime, \`%U\`=owner, \`%n\`=name), plus \`%REPO\`/\`%ORG\` matching your own invented syntax exactly.

Dogfooded for real -- your own GitHub account (created 2013, predates TCOS by over a decade) and a real org repo. Confirmed the exact triggering invocation's "empty" output is correct (no repo component in a user path), not a bug.

Not merged by me.