### PR TITLE
docs(policy): GNU Tools Preference Policy -- real footgun, not style

### DIFF
--- a/docs/doctrine/HEE_POLICY.md
+++ b/docs/doctrine/HEE_POLICY.md
@@ -416,6 +416,38 @@ not a link.
   retrofitted across the rest of the repo, tracked as future cleanup, not
   claimed as done everywhere
 
+### GNU Tools Preference Policy
+
+**Requirement**: target GNU coreutils/GNU tool syntax and behavior by
+default in any script or one-liner — not BSD, not another
+implementation — whenever a real choice exists
+
+**Rationale**: real, well-known, meaningfully different flag syntax
+between implementations, not a style preference. Named example, per
+Spencer directly ("I have that scar"): `sed -i` — GNU allows
+`sed -i 's/x/y/' file` with no argument to `-i`; BSD/macOS `sed`
+*requires* an explicit suffix argument, even an empty one:
+`sed -i '' 's/x/y/' file`. Same-looking invocation, silently different
+(and on BSD, error-if-omitted) behavior — a genuinely common
+cross-platform scripting trap, not a hypothetical one. Same underlying
+hazard class as `date -d` (GNU) vs. `date -v`/`-j -f` (BSD), already
+load-bearing throughout this session's epoch-0 work.
+
+**Enforcement**:
+
+- Default to GNU syntax/behavior in every script and one-liner — this
+  already matches the real environment (Debian-family Linux throughout,
+  including the kiosk reinstall's planned OS) so it's mostly already
+  true in practice, now explicit rather than incidental
+- When a tool's GNU vs. BSD behavior genuinely differs in a
+  security-or-correctness-relevant way (like `sed -i`'s required-vs-
+  optional suffix argument), don't just pick GNU silently — a comment
+  noting the divergence is worth it, the same way `date -d` usage
+  already gets called out when it matters
+- If a script genuinely needs to run on a non-GNU target (a real BSD
+  box, macOS), that's an explicit, stated exception at the point of
+  use — not a default anyone should assume without saying so
+
 ### HEE Rule Violation Documentation
 
 **Process**:

--- a/prompts/PROMPTING_RULES.md
+++ b/prompts/PROMPTING_RULES.md
@@ -24,6 +24,10 @@ the top of a session, per `prompts/INIT.md`.
    invent a new label** — HEE Policy §10/§12.
 5. **When in doubt, stop and ask rather than guess** — same invariant as
    below, restated because it's the one that matters most.
+6. **Target GNU tool syntax/behavior by default**, not BSD or another
+   implementation — real, not stylistic (`sed -i` requires an explicit
+   suffix argument on BSD, optional on GNU; `date -d` is GNU-only) —
+   HEE Policy's GNU Tools Preference Policy.
 
 ## Authority Invariants
 


### PR DESCRIPTION
Your ask, verbatim: "that must be doctrine." Grounded in `sed -i`'s real GNU-vs-BSD divergence (optional suffix arg vs. required, even-if-empty) and `date -d` (GNU-only) -- both already load-bearing this session, not hypothetical. Not merged by me.