### PR TITLE
docs: Protect HEE + observability-is-core -- real doctrine, canonized

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,77 @@ or fragile UI state.
 
 ---
 
+## Protect HEE
+
+Stated directly by Spencer, 2026-08-21, and canonized here rather than
+left as something said once in chat:
+
+> Everything is a threat until we determine we trust it. Once we have
+> `hee-epoch`, we start killing everything we don't own the complete
+> audited history of. This is an always-goal that can never be fully
+> reached, because of the nature of the ask — we keep it always on.
+> HEE provide, HEE protect. **Must** protect HEE. HEE protect: if it
+> ain't correct, it ain't HEE. HEE is math — philosophical "what ifs"
+> are a waste of pencil ink.
+
+**What this actually means, stated plainly:**
+
+- **Default-deny trust.** A claim, a credential, a person, a tool is
+  untrusted until independently verified — not innocent until proven
+  guilty, the reverse. This is the same posture already load-bearing
+  everywhere else in this repo (Thesis vs. Duople, `audit-contracts.py`
+  checking evidence rather than a status label, HEE Policy §6's
+  never-trust-suppressed-silence rule) — this section names the
+  posture itself, not a new rule on top of it.
+- **The audit-everything goal is asymptotic, on purpose.** Complete
+  audited history of everything HEE depends on can never be fully
+  reached — that's acknowledged directly, not treated as a future
+  finish line. The goal stays permanently active anyway, because the
+  alternative (declaring it "done" and relaxing) is worse than never
+  finishing it. Same shape as `primitives`' dependency-removal epic:
+  progress is real even though completion isn't the actual target.
+- **Correctness is the definition, not a quality bar.** "If it ain't
+  correct, it ain't HEE" — a thing that isn't verified isn't a
+  lower-quality instance of HEE, it's simply not HEE at all, by
+  definition. This is why Thesis (unverified) and Duople (verified)
+  are treated as genuinely different *kinds* of thing, not the same
+  kind at different confidence levels.
+- **HEE is math, not speculation.** Ungrounded philosophical
+  hypotheticals don't get engineering effort here — "pencil ink" is
+  the same real image as `hyperscaler to the pencil`: HEE's
+  declarations have to hold at the most basic, physical, unglamorous
+  medium there is, not just in a well-funded cloud environment. A
+  "what if" earns attention once it's stated as a real, testable
+  Thesis with a falsification condition (same bar as
+  `76-26-punk-resurgence.md`'s own Follow-up section) — not before.
+
+## Observability is core, not bolted on
+
+A related, more specific point worth stating separately: HEE is built
+so that no *separate* observability/monitoring layer is needed,
+because verification is core to how the system runs, not a layer
+added after the fact to watch it. Real, not aspirational — every real
+example this session backs it up:
+
+- **Thesis vs. Duople** — a claim's verification state is part of the
+  claim itself, not something a dashboard computes about it later.
+- **`audit-contracts.py`** — checks that a `.asc` evidence file
+  *actually exists* rather than trusting a `status: ratified` label;
+  the audit *is* the ratification mechanism, not a monitor watching it
+  from outside.
+- **Every real dogfood example in this repo's `examples/` directories**
+  — real captured output from a real run, not a synthetic demo,
+  produced as a side effect of the tool actually being used, not a
+  separate instrumentation pass.
+
+Where `extras/observability/` fits into this, honestly: it exists,
+it's real, and it's explicitly self-disclaimed as
+`OPTIONAL / NON-CANONICAL / LOCAL-ONLY` — a demo/experimentation space,
+never part of the real control plane. Checked directly against this
+claim (2026-08-21) rather than assumed — no real contradiction found.
+
+---
+
 ## Thesis vs. Duople
 
 HEE has two content states, and the difference matters:


### PR DESCRIPTION
Your words, canonized rather than left in chat: default-deny trust, the audit-everything goal as explicitly asymptotic and always-on, "if it ain't correct, it ain't HEE" as definitional, HEE as math over speculation.

One editorial call worth flagging directly: I restated this in doctrine register rather than reproducing the more rhetorical/hyperbolic parts literally (the subway car line) -- same lesson as the "deal to sell HEE" line reading alarming out of context to a cold reader. If you want the literal voice preserved somewhere too, that might be a real, separate "Spencer's own words" appendix rather than folded into the doctrine prose itself -- your call.

Also writes up the observability-is-core point with real evidence, not just asserted.

Not merged by me.