### PR TITLE
feat(tooling): hee-ticket -- minimal internal ticket system + real stage tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,10 +60,17 @@ docs/AUTOMATION_CONFIG.json
 # GC Report Pack outputs (generated)
 /var/gc/
 
-# HEE local state - allow specific tracked files
-!.hee/spool/**
-!.hee/evidence/**
-.hee
+# HEE local state. Real fix, 2026-08-21: a bare `.hee` exclusion here,
+# with !.hee/spool/**-style negations meant to re-include specific
+# subdirectories, never actually worked -- git's own documented
+# limitation ("It is not possible to re-include a file if a parent
+# directory of that file is excluded") means the negations were dead
+# code; .hee/spool/ and .hee/evidence/ are only tracked today because
+# their files were force-added once, before anyone hit this. Correct
+# fix: don't exclude .hee/ itself at all -- only the specific
+# subdirectory that's genuinely local-only. spool/, evidence/,
+# tickets/ are untracked-by-default like anything else not listed here.
+.hee/notes/
 
 # node
 node_modules/
@@ -71,11 +78,6 @@ node_modules/
 # local build outputs
 /cmd/hee/hee
 /cmd/hee/cmd/
-
-# committed evidence (track)
-
-# repo-internal scratch (do not commit)
-.hee/
 
 # committed evidence (track)
 !hee/

--- a/.hee/tickets/0001.yaml
+++ b/.hee/tickets/0001.yaml
@@ -1,0 +1,12 @@
+id: '0001'
+created_at: '2026-08-22T01:07:41Z'
+description: perm change for oper/agent@host:/foo/bar
+status: open
+stage: dogfood
+stage_history:
+- stage: idea
+  at: '2026-08-22T01:07:41Z'
+- stage: footgun
+  at: '2026-08-22T01:07:41Z'
+- stage: dogfood
+  at: '2026-08-22T01:07:41Z'

--- a/examples/hee-ticket-output.md
+++ b/examples/hee-ticket-output.md
@@ -1,0 +1,81 @@
+# `hee-ticket` — real run
+
+Real trigger, 2026-08-21: "we need a workflow for that... internal
+system" — `./hee ticket -new 'perm change for oper/agent@host:/foo/bar'`.
+Dogfooded with that exact example, not a synthetic one — including a
+real footgun found along the way (see below), same idea->footgun->dogfood
+pipeline this tool's own `stage` field now tracks.
+
+```
+$ ./hee ticket -new 'perm change for oper/agent@host:/foo/bar'
+hee-ticket 0001: perm change for oper/agent@host:/foo/bar
+  stage: idea
+  .hee/tickets/0001.yaml
+
+$ ./hee ticket -advance 0001
+hee-ticket 0001: idea -> footgun
+
+$ ./hee ticket -advance 0001
+hee-ticket 0001: footgun -> dogfood
+
+$ ./hee ticket -advance 0001
+hee-ticket 0001: already at final stage (dogfood), nothing to advance to
+
+$ ./hee ticket -list
+0001  [open]  (dogfood)  perm change for oper/agent@host:/foo/bar  (2026-08-22T01:07:41Z)
+
+$ cat .hee/tickets/0001.yaml
+id: '0001'
+created_at: '2026-08-22T01:07:41Z'
+description: perm change for oper/agent@host:/foo/bar
+status: open
+stage: dogfood
+stage_history:
+- stage: idea
+  at: '2026-08-22T01:07:41Z'
+- stage: footgun
+  at: '2026-08-22T01:07:41Z'
+- stage: dogfood
+  at: '2026-08-22T01:07:41Z'
+```
+
+## A real footgun this tool hit on itself
+
+First version shipped `-advance` in the docstring/usage text but never
+actually registered it as an `argparse` argument — caught immediately
+by running it for real, not by code review:
+
+```
+$ ./tooling/bin/hee ticket -advance 0001
+usage: hee-ticket [-new DESCRIPTION] [-list]
+hee-ticket: error: unrecognized arguments: -advance 0001
+```
+
+Fixed, re-verified with the real output above.
+
+## A second, real footgun: `.gitignore` itself
+
+`.hee/tickets/0001.yaml` couldn't be `git add`ed at all initially --
+`.gitignore` had `!.hee/spool/**`-style negation patterns meant to
+re-include specific `.hee/` subdirectories, but git's own documented
+limitation ("It is not possible to re-include a file if a parent
+directory of that file is excluded") means those negations never
+actually worked. `.hee/spool/` and `.hee/evidence/` are only tracked
+today because their files were force-added once, before anyone hit
+this. Real fix: stopped excluding `.hee/` broadly at all -- only
+`.hee/notes/` (genuinely local-only, confirmed untracked) is excluded
+now; `spool/`, `evidence/`, `tickets/` are untracked-by-default like
+anything else not listed.
+
+## Explicitly not built here
+
+- Structured target parsing (`oper/agent@host:/foo/bar` as a real
+  namespaced value, the way `hee-stat`'s `gh/OWNER/REPO` is) — the
+  description is free text for now. Worth revisiting once the
+  notation itself proves out across more than one example.
+- Status transitions beyond `open` (no `-close` yet).
+- Anything resembling GitHub Issues' real feature set (labels,
+  cross-references, Projects). This is the smallest real step, not a
+  replacement — see [`primitives#5`](https://github.com/Twin-Cities-Open-Systems/primitives/issues/5)
+  for the real, larger, not-yet-decided question this is one step
+  toward answering, not a decision that it's the answer.

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -14,3 +14,9 @@ Tools:
 - tooling/bin/hee-attach  : attach doctrine locally without committing it (detached mode)
 - tooling/bin/hee-sync-cursor-prompts : derive .cursor/prompts from the active policy source
 - tooling/bin/hee-check   : boundary/compliance checks
+- tooling/bin/hee-ticket  : `-new "description"` / `-list` -- real, minimal first step of an
+  internal ticket system (GitHub Issues is an external dependency for all of TCOS's tracking
+  right now, same class of concern as `primitives`'s dependency-removal work). Stores one real
+  YAML record per ticket in `.hee/tickets/` (sibling of `.hee/spool/`'s existing phase-tracking
+  records, not a new convention). Prototype/dogfood, not yet declared standard practice over
+  GitHub Issues. See `examples/hee-ticket-output.md`.

--- a/tooling/bin/hee-ticket
+++ b/tooling/bin/hee-ticket
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""hee-ticket -- the real, minimal first step of an internal ticket
+system, dogfooded, not the full thing.
+
+Real trigger (2026-08-21): "we need a workflow for that, ticket may
+not be right and just glogging gh, we need internal ticket system...
+./hee ticket -new 'perm change for oper/agent@host:/foo/bar'". GitHub
+Issues is itself an external dependency for all of TCOS's tracking
+(same class of concern as primitives#5's dependency-removal work) --
+this is the smallest real, dogfoodable step toward a TCOS-owned
+alternative, not a declaration that it replaces GitHub Issues as
+standard practice yet.
+
+Storage: `.hee/tickets/<id>.yaml`, one real record per ticket -- .hee/
+is already real, git-tracked working-state (see .hee/spool/*.yaml's
+phase_id/status/timestamps shape, same idea, this is a sibling of
+that, not a new convention invented from nothing).
+
+Real trigger for the `stage` field specifically (2026-08-21): Spencer's
+own pseudocode, `idea:{1,}->footgun:{1,}->dogfood:{1,}` -- the real
+idea->footgun->dogfood pipeline named as a heeism much earlier the same
+session, now made structural rather than staying prose-only. Real,
+not aspirational: `stage_history` records every transition with a
+timestamp, so "how many tickets are actually at each stage, and how
+long did each stage take" is a real, derivable count -- not asserted.
+
+Usage:
+  hee-ticket -new "description text"
+  hee-ticket -list
+  hee-ticket -advance ID     # idea -> footgun -> dogfood, one step at a time
+"""
+import argparse
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("Requires pyyaml: pip install pyyaml")
+
+STAGES = ["idea", "footgun", "dogfood"]
+
+
+def repo_root() -> Path:
+    out = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit("hee-ticket: not inside a git repo")
+    return Path(out.stdout.strip())
+
+
+def tickets_dir() -> Path:
+    d = repo_root() / ".hee" / "tickets"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def next_id(d: Path) -> str:
+    existing = sorted(p.stem for p in d.glob("*.yaml") if p.stem.isdigit())
+    n = int(existing[-1]) + 1 if existing else 1
+    return f"{n:04d}"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def cmd_new(description: str):
+    d = tickets_dir()
+    tid = next_id(d)
+    ts = now_iso()
+    record = {
+        "id": tid,
+        "created_at": ts,
+        "description": description,
+        "status": "open",
+        "stage": STAGES[0],
+        "stage_history": [{"stage": STAGES[0], "at": ts}],
+    }
+    path = d / f"{tid}.yaml"
+    with open(path, "w") as f:
+        yaml.safe_dump(record, f, sort_keys=False)
+    print(f"hee-ticket {tid}: {description}")
+    print(f"  stage: {STAGES[0]}")
+    print(f"  {path.relative_to(repo_root())}")
+
+
+def cmd_advance(tid: str):
+    tid = tid.zfill(4)
+    path = tickets_dir() / f"{tid}.yaml"
+    if not path.exists():
+        sys.exit(f"hee-ticket: no ticket {tid}")
+    with open(path) as f:
+        rec = yaml.safe_load(f)
+    cur = rec.get("stage", STAGES[0])
+    if cur not in STAGES:
+        sys.exit(f"hee-ticket: unknown stage '{cur}' on ticket {tid} -- can't advance")
+    idx = STAGES.index(cur)
+    if idx == len(STAGES) - 1:
+        print(f"hee-ticket {tid}: already at final stage ({cur}), nothing to advance to")
+        return
+    new_stage = STAGES[idx + 1]
+    rec["stage"] = new_stage
+    rec.setdefault("stage_history", []).append({"stage": new_stage, "at": now_iso()})
+    with open(path, "w") as f:
+        yaml.safe_dump(rec, f, sort_keys=False)
+    print(f"hee-ticket {tid}: {cur} -> {new_stage}")
+
+
+def cmd_list():
+    d = tickets_dir()
+    tickets = sorted(d.glob("*.yaml"))
+    if not tickets:
+        print("No tickets yet.")
+        return
+    for p in tickets:
+        with open(p) as f:
+            rec = yaml.safe_load(f)
+        stage = rec.get("stage", "?")
+        print(f"{rec['id']}  [{rec['status']}]  ({stage})  {rec['description']}  ({rec['created_at']})")
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("-new", dest="new_desc", metavar="DESCRIPTION")
+    ap.add_argument("-list", action="store_true")
+    ap.add_argument("-advance", dest="advance_id", metavar="ID")
+    args = ap.parse_args()
+
+    if args.new_desc:
+        cmd_new(args.new_desc)
+    elif args.list:
+        cmd_list()
+    elif args.advance_id:
+        cmd_advance(args.advance_id)
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Your exact example, dogfooded for real: \`./hee ticket -new 'perm change for oper/agent@host:/foo/bar'\` -- and "yes, for realz" on making \`idea->footgun->dogfood\` a real, structural field, not just prose notation.

\`-new\`/\`-list\`/\`-advance\`, real YAML records in \`.hee/tickets/\`, zero router changes -- same pattern as \`hee-stat\` (HEE#267).

Hit and fixed two real footguns while dogfooding this, both written up honestly in the example rather than silently patched: \`-advance\` shipped in the docstring but not the actual argparse args (caught by running it), and \`.gitignore\`'s negation patterns for \`.hee/\` subdirectories never actually worked at all -- a real git limitation, not a typo. Fixed for real, not worked around.

Smallest real step toward [primitives#5](https://github.com/Twin-Cities-Open-Systems/primitives/issues/5)'s bigger question, not a declared GitHub Issues replacement.

Not merged by me.