### PR TITLE
feat(tooling): hee-con + hee-shell -- native IRC client + host-alias ssh

### DIFF
--- a/tooling/bin/hee-con
+++ b/tooling/bin/hee-con
@@ -1,0 +1,104 @@
+#!/bin/sh
+# hee-con -- connect to IRC using a real native client, persistent in tmux.
+#
+# Real trigger (2026-08-22): Spencer wanted `./hee con -irc <channel>` after
+# a one-shot raw-socket #tclug check (join, read the roster, quit -- see
+# hee-lg's sibling read-only pattern) wasn't what he actually needed. His own
+# words: "give me the native every time" -- this launches a real, established
+# IRC client (irssi, falling back to weechat) rather than reimplementing the
+# protocol, and leaves it running in a detached tmux session so the
+# connection is persistent, not a snapshot.
+#
+# usage:
+#   hee-con -irc <channel> [-network HOST] [-session NAME] [-nick NICK]
+#
+# design:
+#   - real native client (irssi/weechat), not a custom protocol client
+#   - detached tmux session -- survives after this command returns;
+#     attach with: tmux attach -t <session>
+#   - if a session with that name is already running, attaches info
+#     instead of starting a second, conflicting connection
+
+set -eu
+
+usage() {
+  cat <<'TXT'
+hee-con -- connect to IRC with a real native client, persistent in tmux
+
+usage:
+  hee-con -irc <channel> [-network HOST] [-session NAME] [-nick NICK]
+
+defaults:
+  -network irc.libera.chat
+  -session irc-<channel, # stripped>
+  -nick    hee<pid>
+TXT
+}
+
+network="irc.libera.chat"
+session=""
+nick=""
+channel=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -irc) channel="${2:-}"; shift 2 ;;
+    -network) network="${2:-}"; shift 2 ;;
+    -session) session="${2:-}"; shift 2 ;;
+    -nick) nick="${2:-}"; shift 2 ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) echo "hee-con: unknown arg: $1" 1>&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$channel" ]; then
+  echo "hee-con: -irc <channel> is required" 1>&2
+  usage
+  exit 1
+fi
+
+case "$channel" in
+  "#"*) ;;
+  *) channel="#${channel}" ;;
+esac
+
+[ -z "$session" ] && session="irc-$(printf '%s' "$channel" | tr -d '#')"
+[ -z "$nick" ] && nick="hee$$"
+
+client_cmd=""
+client_name=""
+if command -v irssi >/dev/null 2>&1; then
+  client_name="irssi"
+  client_cmd="irssi -c ${network} -n ${nick}"
+elif command -v weechat >/dev/null 2>&1; then
+  client_name="weechat"
+  client_cmd="weechat"
+else
+  echo "hee-con: no native IRC client found (irssi or weechat)" 1>&2
+  echo "hee-con: install one first, e.g.: sudo apt install irssi" 1>&2
+  exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "hee-con: tmux not found -- required to run a persistent session" 1>&2
+  exit 1
+fi
+
+if tmux has-session -t "$session" 2>/dev/null; then
+  echo "hee-con: session '${session}' is already running"
+  echo "hee-con: attach with: tmux attach -t ${session}"
+  exit 0
+fi
+
+tmux new-session -d -s "$session" "$client_cmd"
+sleep 2
+
+if [ "$client_name" = "irssi" ]; then
+  tmux send-keys -t "$session" "/join ${channel}" Enter
+else
+  echo "hee-con: started weechat -- join ${channel} manually (/connect + /join)" 1>&2
+fi
+
+echo "hee-con: '${session}' started -- ${client_name} connecting to ${network} as ${nick}, joining ${channel}"
+echo "hee-con: attach with: tmux attach -t ${session}"
+echo "hee-con: detach without killing it: Ctrl-b then d"

--- a/tooling/bin/hee-shell
+++ b/tooling/bin/hee-shell
@@ -1,0 +1,48 @@
+#!/bin/sh
+# hee-shell -- ssh into a known TCOS host by short alias.
+#
+# Real, deliberately thin: this is `ssh` with TCOS's own host aliases
+# baked in, not a new protocol or a permissions mechanism. It cannot
+# grant access a key doesn't already have -- if the calling session's
+# key isn't authorized on the target host/account, this fails exactly
+# like a bare `ssh` call would, with the same real error.
+#
+# Alias table only includes hosts actually confirmed reachable by name
+# this session -- not speculative. Add more here as they're verified,
+# not guessed.
+#
+# usage:
+#   hee-shell <alias|host> [user]
+
+set -eu
+
+usage() {
+  cat <<'TXT'
+hee-shell -- ssh into a known TCOS host by alias
+
+usage:
+  hee-shell <alias|host> [user]
+
+known aliases:
+  kiosk -> kiosk.lab.tcos.us
+TXT
+}
+
+target="${1:-}"
+user="${2:-}"
+
+if [ -z "$target" ]; then
+  usage
+  exit 1
+fi
+
+case "$target" in
+  kiosk) host="kiosk.lab.tcos.us" ;;
+  *) host="$target" ;;
+esac
+
+if [ -n "$user" ]; then
+  exec ssh "${user}@${host}"
+else
+  exec ssh "$host"
+fi


### PR DESCRIPTION
## What

- `hee-con -irc <channel>` -- launches a real native IRC client (irssi,
  falling back to weechat) in a detached tmux session, so the connection
  persists rather than being a one-shot check. Real trigger: Spencer's
  own words after an earlier raw-socket #tclug check, "give me the
  native every time."
- `hee-shell <alias|host> [user]` -- deliberately thin ssh-with-aliases
  wrapper. Grants nothing a key doesn't already have; verified it fails
  exactly like bare `ssh` would when run from an unauthorized sandbox.

## Real, named constraint (not a bug)

`spencer@kiosk` (and per Spencer, `spencer@<host>` generally) is a
**permanent dogfood account** -- no sudo, no privileged workaround, by
design. `hee-con` needing irssi/weechat pre-installed there is a real
blocker that has to be solved by a privileged identity provisioning it
ahead of time, never by elevating the dogfood account. Both tools assume
zero privilege escalation is ever available where they're actually used.

## Not yet live-dogfooded end to end

The sandbox this was built in has no authorized key on kiosk at all, so
full verification (`hee-con -irc tclug` actually landing a live irssi
session someone can attach to) still needs to happen from a session that
does have kiosk access. `hee-shell`'s honest-failure behavior against
kiosk from this same sandbox was verified directly.

Self-assigning per HEE Policy §10.