### PR TITLE
feat(tooling): hee-procmail -- procmail's real interface, adapted rules

### DIFF
--- a/examples/hee-procmail-output.md
+++ b/examples/hee-procmail-output.md
@@ -1,0 +1,59 @@
+# `hee-procmail` — real run
+
+Real trigger: spitballing an email-to-IRC relay
+(`hee-irc+<channel>@tcos.us` -> `hee-con -irc <channel>`, see
+[fleet-ops#224](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/224))
+landed on "procmail's spirit, adapted syntax" per Spencer's own verdict:
+"fuck yes to procmailrc, I fucking hate that thing. very hee."
+
+Rule file (`.hee/mailrules.yaml`):
+
+```yaml
+rules:
+  - name: irc-relay
+    match:
+      header: To
+      plus_of: hee-irc
+    action: "echo hee-con -irc {tag}"
+  - name: ping
+    match:
+      header: Subject
+      regex: "^ping"
+    action: "echo pong"
+```
+
+Four real cases, piped via stdin exactly the way an MTA would invoke it:
+
+```
+$ printf 'From: spencer@tcos.us\r\nTo: hee-irc+tclug@tcos.us\r\nSubject: join please\r\n\r\nbody\r\n' | hee-procmail
+hee-procmail: rule 'irc-relay' matched -> ['echo', 'hee-con', '-irc', 'tclug']
+hee-con -irc tclug
+
+$ printf 'From: spencer@tcos.us\r\nTo: someone@tcos.us\r\nSubject: ping\r\n\r\nbody\r\n' | hee-procmail
+hee-procmail: rule 'ping' matched -> ['echo', 'pong']
+pong
+
+$ printf 'From: spencer@tcos.us\r\nTo: someone@tcos.us\r\nSubject: unrelated\r\n\r\nbody\r\n' | hee-procmail
+hee-procmail: no rule matched -- message dropped
+
+$ printf 'From: spencer@tcos.us\r\nTo: hee-irc+tclug; rm -rf /@tcos.us\r\nSubject: x\r\n\r\nbody\r\n' | hee-procmail
+hee-procmail: rule 'irc-relay' matched but tag 'tclug; rm -rf /' failed safe-charset check -- skipping
+hee-procmail: no rule matched -- message dropped
+```
+
+The last case is the one that actually matters: a hostile `To` header
+that would be a real shell-injection footgun in a naive procmail-style
+config (unquoted extracted value flowing into a shell action) is caught
+by the safe-charset check before it ever reaches `shlex`/`subprocess`.
+
+## Explicitly not built here
+
+- No real MTA/mail-server wiring -- this reads a message from stdin,
+  same real interface procmail uses, but nothing delivers mail to it
+  yet. That's `mx-N.tcos.us`'s dependency, not this tool's.
+- No `regex` capture-group substitution beyond `{match}` (the whole
+  matched text) -- `plus_of`'s `{tag}` is the only structured extraction
+  today. Add named groups if a real rule needs more.
+- No stop/continue flag system like real procmail's `:0`/`:0c` -- first
+  matching rule wins, full stop. Deliberate simplification, not
+  forgotten scope.

--- a/tooling/bin/hee-procmail
+++ b/tooling/bin/hee-procmail
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""hee-procmail -- procmail's real interface, an adapted rule syntax.
+
+Real trigger (2026-08-22): spitballing an email-to-IRC relay
+(`hee-irc+<channel>@tcos.us` -> `hee-con -irc <channel>`, see
+fleet-ops#224) surfaced the real question of what actually parses
+incoming mail. Spencer's own verdict on the two known options: "fuck
+yes to procmailrc, I fucking hate that thing. very hee" -- likes
+procmail's spirit (an MTA pipes the raw message to a program on stdin,
+rules decide what happens), not its syntax (fragile regex-on-raw-text,
+`.procmailrc`'s notoriously easy-to-get-subtly-wrong whitespace rules).
+
+What's kept from real procmail: the stdin interface itself -- this is
+still "the MTA execs this with the message on stdin," the actual
+authentic part, not reinvented.
+
+What's adapted: rules are real YAML, not procmail's positional-flag
+syntax; header parsing goes through Python's real `email` module
+instead of raw regex-on-headers; and dispatch never goes through a
+shell string (shlex-split + subprocess with shell=False) specifically
+because naive procmail configs are a well-known shell-injection
+footgun when a rule's extracted value flows into an unquoted shell
+action -- closing that off is the one non-negotiable improvement, not
+just taste.
+
+Usage (procmail-real interface -- message on stdin):
+  hee-procmail [-rules PATH] < message.eml
+
+Rule file format (default: .hee/mailrules.yaml in the current repo):
+  rules:
+    - name: irc-relay
+      match:
+        header: To
+        plus_of: hee-irc      # matches hee-irc+<tag>@anything, captures <tag>
+      action: "tooling/bin/hee-con -irc {tag}"
+    - name: ping
+      match:
+        header: Subject
+        regex: "^ping"
+      action: "echo pong"
+
+First matching rule wins and runs; this is a deliberate simplification
+of real procmail's much richer flag system (:0, lockfiles, nesting),
+not a claim of full parity.
+"""
+import argparse
+import email
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("hee-procmail: requires pyyaml: pip install pyyaml")
+
+SAFE_TAG = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def load_rules(path: Path):
+    if not path.exists():
+        sys.exit(f"hee-procmail: no rule file at {path}")
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("rules", [])
+
+
+def match_rule(rule, msg):
+    match = rule.get("match", {})
+    header_name = match.get("header")
+    if not header_name:
+        return None
+    value = msg.get(header_name, "")
+    if not value:
+        return None
+
+    if "plus_of" in match:
+        local = re.escape(match["plus_of"])
+        m = re.search(rf"{local}\+([^@]+)@", value)
+        if not m:
+            return None
+        tag = m.group(1)
+        if not SAFE_TAG.match(tag):
+            print(f"hee-procmail: rule '{rule.get('name')}' matched but tag "
+                  f"'{tag}' failed safe-charset check -- skipping", file=sys.stderr)
+            return None
+        return {"tag": tag}
+
+    if "regex" in match:
+        m = re.search(match["regex"], value)
+        if not m:
+            return None
+        return {"match": m.group(0)}
+
+    return None
+
+
+def run_action(rule, fields):
+    action = rule.get("action")
+    if not action:
+        sys.exit(f"hee-procmail: rule '{rule.get('name')}' has no action")
+    argv = [tok.format(**fields) for tok in shlex.split(action)]
+    print(f"hee-procmail: rule '{rule.get('name')}' matched -> {argv}", file=sys.stderr)
+    subprocess.run(argv, shell=False, check=False)
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="hee-procmail")
+    ap.add_argument("-rules", default=".hee/mailrules.yaml", metavar="PATH")
+    args = ap.parse_args()
+
+    raw = sys.stdin.buffer.read()
+    if not raw:
+        sys.exit("hee-procmail: empty message on stdin")
+    msg = email.message_from_bytes(raw)
+
+    rules = load_rules(Path(args.rules))
+    for rule in rules:
+        fields = match_rule(rule, msg)
+        if fields is not None:
+            run_action(rule, fields)
+            return
+
+    print("hee-procmail: no rule matched -- message dropped", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`tooling/bin/hee-procmail` -- the missing "other half" of the
email-to-IRC relay idea ([fleet-ops#224](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/224)).
`hee-con` ([HEE#277](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/pull/277))
is the action side; this is real dispatch.

Keeps procmail's actual interface (message piped to stdin by the MTA).
Replaces its syntax with YAML rules + Python's real `email` module for
header parsing, per Spencer's own verdict: "fuck yes to procmailrc, I
fucking hate that thing. very hee."

## The one non-negotiable change, not just taste

Naive procmail configs are a well-known shell-injection footgun when an
extracted header value flows into an unquoted shell action. This never
builds a shell string -- values are charset-validated, then dispatched
via `shlex` + `subprocess(shell=False)`. Verified directly: a hostile
plus-address tag (`tclug; rm -rf /`) is caught and the rule skipped, not
executed. See `examples/hee-procmail-output.md`.

## Dogfooded

Four real synthetic messages piped via stdin -- match, regex-fallback
match, no-match, and the injection-safety case. All four pass.

## Not built here

No real MTA wiring -- needs `mx-N.tcos.us`
([HEE#275](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/pull/275)'s
dependency, not this tool's).

Self-assigning per HEE Policy §10.