### PR TITLE
feat(tooling): hee-net -- protocol-aware fetch, starting with gopher

### DIFF
--- a/examples/hee-net-finger-output.md
+++ b/examples/hee-net-finger-output.md
@@ -1,0 +1,29 @@
+# `hee-net -proto finger` — real run
+
+Real trigger: "finger and gopher and snmp will be good buds" -- same
+family of old, simple, text-based query protocols. `hee-net` was
+already built with `-proto` as an extension point; finger is the
+second real protocol on it.
+
+```
+$ hee-net -proto finger -query spencer
+Login: spencer        			Name: Spencer Butler
+Directory: /home/spencer            	Shell: /bin/bash
+On since Fri Aug 21 16:46 (CDT) on pts/0 from 10.0.0.239
+    ...
+```
+
+Local queries (`-query <user>`, no `@host`) shell out to the real
+`finger(1)` client rather than reimplementing local session/`.plan`
+lookup -- that's real, already-correct system behavior, not something
+to duplicate. Remote queries (`-query user@host[:port]`) speak RFC 1288
+directly over a raw socket, same shape as the gopher fetch.
+
+Gopher re-verified working after this change (byte-identical to the
+earlier run) -- the two protocols share `hee-net`'s dispatch, not
+implementation.
+
+## Explicitly not built here
+
+- No remote fingerd exists yet to test the `user@host` path against a
+  real server -- structurally correct per RFC 1288, not live-verified.

--- a/examples/hee-net-output.md
+++ b/examples/hee-net-output.md
@@ -1,0 +1,26 @@
+# `hee-net` — real run
+
+Real trigger: Chrome dropped native `gopher://` support years ago --
+"chrome no first try." Fetched `gopher://gopher.quux.org:70/1/Software/Gopher`
+directly via a raw socket first, then wrapped into a real, reusable tool.
+
+```
+$ ./hee net -proto gopher -url "gopher://gopher.quux.org:70/1/Software/Gopher"
+iTHE GOPHER PROJECT	/Software/Gopher/fake	gopher.quux.org	70
+i------------------	/Software/Gopher/fake	gopher.quux.org	70
+...
+1Clients, Servers, and Downloads	/Software/Gopher/Downloads	gopher.quux.org	70	+
+1Major Gopher Servers	/Software/Gopher/servers	gopher.quux.org	70	+
+1Using Gopher	/Software/Gopher/using	gopher.quux.org	70	+
+```
+
+Output matches a raw manual fetch byte-for-byte.
+
+## Explicitly not built here
+
+- Only gopher today (`-proto` takes one choice) -- the flag shape is
+  there for whatever real protocol comes next, not a promise of a
+  general-purpose fetcher.
+- No item-type-aware rendering (menu vs text vs binary) -- prints the
+  raw response either way. Real gopher clients render menus as
+  navigable lists; this is a fetch tool, not a browser.

--- a/tooling/bin/hee-net
+++ b/tooling/bin/hee-net
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""hee-net -- protocol-aware fetch, starting with gopher.
+
+Real trigger (2026-08-22): Chrome dropped native gopher:// support years
+ago -- "chrome no first try." Real gopher URL fetched directly via raw
+socket first (gopher.quux.org, /Software/Gopher), then wrapped into a
+real, reusable tool matching the session's pattern (hee-lg for BGP,
+hee-con for IRC, this for gopher and whatever protocol comes next).
+
+Gopher itself is a dead-simple protocol (RFC 1436): connect, send the
+selector line + CRLF, read plaintext back until the connection closes
+or a lone "." line. No auth, no TLS in the original spec. This is a
+real client for it, not a simulation.
+
+Usage:
+  hee-net -proto gopher -url gopher://host[:port]/[type]selector
+"""
+import argparse
+import socket
+import sys
+from urllib.parse import urlparse
+
+
+def fetch_gopher(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "gopher":
+        sys.exit(f"hee-net: not a gopher:// URL: {url}")
+    host = parsed.hostname
+    port = parsed.port or 70
+    path = parsed.path or "/1"
+    # First path char after the leading "/" is the gopher item type digit;
+    # the real selector to send is everything after that.
+    selector = path[2:] if len(path) > 1 else ""
+
+    with socket.create_connection((host, port), timeout=15) as sock:
+        sock.sendall((selector + "\r\n").encode())
+        chunks = []
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    return b"".join(chunks).decode(errors="replace")
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="hee-net")
+    ap.add_argument("-proto", required=True, choices=["gopher"])
+    ap.add_argument("-url", required=True)
+    args = ap.parse_args()
+
+    if args.proto == "gopher":
+        print(fetch_gopher(args.url))
+
+
+if __name__ == "__main__":
+    main()

--- a/tooling/bin/hee-net
+++ b/tooling/bin/hee-net
@@ -12,11 +12,19 @@ selector line + CRLF, read plaintext back until the connection closes
 or a lone "." line. No auth, no TLS in the original spec. This is a
 real client for it, not a simulation.
 
+Real trigger for finger (2026-08-22): "finger and gopher and snmp will
+be good buds" -- same family of old, simple, text-based query
+protocols. finger (RFC 1288) is dead simple too: connect to port 79,
+send "user\r\n" (or "\r\n" alone for a full listing), read plaintext
+back until the connection closes.
+
 Usage:
   hee-net -proto gopher -url gopher://host[:port]/[type]selector
+  hee-net -proto finger -query user[@host[:port]]
 """
 import argparse
 import socket
+import subprocess
 import sys
 from urllib.parse import urlparse
 
@@ -43,14 +51,42 @@ def fetch_gopher(url: str) -> str:
     return b"".join(chunks).decode(errors="replace")
 
 
+def fetch_finger(query: str) -> str:
+    if "@" in query:
+        user, hostport = query.split("@", 1)
+        host, _, port = hostport.partition(":")
+        port = int(port) if port else 79
+        with socket.create_connection((host, port), timeout=10) as sock:
+            sock.sendall((user + "\r\n").encode())
+            chunks = []
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        return b"".join(chunks).decode(errors="replace")
+    else:
+        # local user -- real finger(1) already does this correctly
+        # (reads .plan, login sessions, etc.) -- no reason to reimplement it
+        result = subprocess.run(["finger", query], capture_output=True, text=True)
+        return result.stdout or result.stderr
+
+
 def main():
     ap = argparse.ArgumentParser(prog="hee-net")
-    ap.add_argument("-proto", required=True, choices=["gopher"])
-    ap.add_argument("-url", required=True)
+    ap.add_argument("-proto", required=True, choices=["gopher", "finger"])
+    ap.add_argument("-url")
+    ap.add_argument("-query")
     args = ap.parse_args()
 
     if args.proto == "gopher":
+        if not args.url:
+            sys.exit("hee-net: -url required for -proto gopher")
         print(fetch_gopher(args.url))
+    elif args.proto == "finger":
+        if not args.query:
+            sys.exit("hee-net: -query required for -proto finger")
+        print(fetch_finger(args.query))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

\`hee-net -proto gopher -url gopher://host[:port]/[type]selector\` --
real gopher client (RFC 1436: connect, send selector + CRLF, read
plaintext back). Real trigger: Chrome dropped native \`gopher://\`
support, needed \`gopher://gopher.quux.org:70/1/Software/Gopher\`
fetched directly.

## Dogfooded

Output matches a raw manual socket fetch byte-for-byte. See
\`examples/hee-net-output.md\`.

Self-assigning per HEE Policy §10.