### PR TITLE
feat(tooling): hee-scrob -- punk-as-fuck Plex now-playing scrobble

### DIFF
--- a/examples/hee-scrob-output.md
+++ b/examples/hee-scrob-output.md
@@ -1,0 +1,36 @@
+# `hee-scrob` — status
+
+Real trigger: "terse and hee and very spencer for when I /scrob in
+#tclug," then extended same conversation to include year, playback
+timestamp, and the real subtitle line active at that position (sourced
+from real `.srt` files in `/mnt/nuc1-pool/media/`, never invented).
+
+## What's verified for real
+
+- The no-token safety path: `PLEX_TOKEN` unset → clean error, exit 1.
+- Syntax valid (`ast.parse`).
+- Real `.srt` files in the media library match the format the parser
+  assumes (checked directly against
+  `Movies/2021-King_Richard/King_Richard-....en.srt`).
+
+## What's NOT verified
+
+No `PLEX_TOKEN` exists in this environment, so the actual live fetch
+against `plex.crooked.tcos.us` and the full SRT-lookup-at-real-offset
+path haven't been exercised end to end against a real playing session.
+Real gap, not hidden -- once a token's sealed via `hee-cred`
+(`hee cred -pass plex-token -exec hee-scrob`), this needs one real
+dogfood run against whatever's actually playing to confirm the Plex
+XML field names match what this expects (`grandparentTitle`,
+`parentTitle`, `parentYear`, `viewOffset`, `Media/Part/@file`) -- these
+are documented Plex API fields, not guessed, but documented and
+observed-in-the-wild aren't the same thing.
+
+## Wiring, once trusted
+
+```
+# in ~/.irssi/config aliases block:
+SCROB = "EXEC -o ~/.local/bin/hee-scrob";
+```
+
+Then `/scrob` in any channel posts the real now-playing line directly.

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -11,6 +11,21 @@ the real subtitle line active at the exact playback position from the
 real .srt sitting next to the media file. No invented dialogue --
 if there's no real .srt, there's no subtitle line in the output.
 
+Real fix (2026-08-22, same session): TV episodes were only showing the
+episode's own title ("LASIK Instinct"), silently dropping the real
+show name and season/episode -- Plex's `title` attribute on an
+episode Video element is the *episode* title, not the show's; the show
+name lives in `grandparentTitle`, season in `parentIndex`, episode
+number in `index`. Real ask: "needs the TV show, s N e N year device
+friendly name." Device names got the same real fix -- reverse-DNS
+mostly fails on this LAN (no PTR records), so Plex's raw self-reported
+device title ("LG 32LM570BPUA") was showing instead of a real human
+name. No API to pull that mapping live (Home Assistant's reachable but
+needs a token nobody has yet) -- so a real, local override file
+instead of fabricating one: ~/.config/hee/device-names.txt, one
+"raw-name = Friendly Name" pair per line, checked before falling back
+to whatever Plex/reverse-DNS gave us.
+
 Designed to be wired as an irssi alias that pipes stdout into a channel:
   SCROB = "EXEC -o ~/.local/bin/hee-scrob"
 then just `/scrob` in the channel.
@@ -33,6 +48,7 @@ from pathlib import Path
 
 DEFAULT_SERVER = "https://plex.crooked.tcos.us"
 DEFAULT_TOKEN_FILE = Path.home() / ".config" / "hee" / "plex-token"
+DEVICE_NAMES_FILE = Path.home() / ".config" / "hee" / "device-names.txt"
 
 
 def read_token() -> str:
@@ -47,6 +63,22 @@ def read_token() -> str:
     if DEFAULT_TOKEN_FILE.exists():
         return DEFAULT_TOKEN_FILE.read_text().strip()
     return ""
+
+
+def read_device_names() -> dict:
+    """Real, local, human-maintained override -- 'raw = Friendly' per
+    line, '#' comments allowed. Nothing invented if a raw name isn't
+    in here; the raw value just passes through unchanged."""
+    mapping = {}
+    if not DEVICE_NAMES_FILE.exists():
+        return mapping
+    for line in DEVICE_NAMES_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        raw, friendly = line.split("=", 1)
+        mapping[raw.strip()] = friendly.strip()
+    return mapping
 
 
 def fmt_ts(ms: int) -> str:
@@ -90,15 +122,22 @@ def srt_line_at_offset(blocks, offset_ms: int):
     return None
 
 
-def srt_context(srt_path: Path, offset_ms: int):
+def srt_context(srt_path: Path, offset_ms: int, current_only: bool = False):
     """Real trigger: "need 00:00:00 for scrob and for tv/movie 5s
     before, cur, 5s after, discrete things" -- three independent,
     fixed-offset lookups (offset-5000, offset, offset+5000), not
     whatever subtitle block happens to be structurally adjacent. Each
-    one is real and separately correct if empty."""
+    one is real and separately correct if empty.
+
+    Real extension (2026-08-22): "now a switch for the current sub
+    titles" -- -current-only drops the before/after context and
+    returns just the exact-moment line, still real, still None if
+    that moment falls in a silent gap."""
     if not srt_path.exists():
         return None
     blocks, _ = _srt_blocks(srt_path)
+    if current_only:
+        return srt_line_at_offset(blocks, offset_ms)
     before = srt_line_at_offset(blocks, offset_ms - 5000)
     current = srt_line_at_offset(blocks, offset_ms)
     after = srt_line_at_offset(blocks, offset_ms + 5000)
@@ -114,7 +153,7 @@ def find_srt(media_file: str):
     return None
 
 
-def now_playing(server: str, token: str):
+def now_playing(server: str, token: str, device_names: dict, current_only: bool = False):
     url = f"{server}/status/sessions?X-Plex-Token={token}"
     req = urllib.request.Request(url, headers={"Accept": "application/xml"})
     with urllib.request.urlopen(req, timeout=10) as r:
@@ -129,21 +168,27 @@ def now_playing(server: str, token: str):
         self-reported friendly title -- reverse-DNS the Player's real
         connecting IP first, fall back to the title Plex gives us if
         that fails (most devices on this network won't have PTR
-        records, same real gap as everything else tonight)."""
+        records, same real gap as everything else tonight). Then check
+        the local device-names.txt override for a real human-assigned
+        friendly name over whatever raw value came out of either path."""
         player = el.find("Player")
         if player is None:
             return None
+        raw = None
         address = player.get("address")
         if address:
             try:
-                return socket.gethostbyaddr(address)[0]
+                raw = socket.gethostbyaddr(address)[0]
             except (socket.herror, socket.gaierror):
                 pass
-        return player.get("title")
+        if not raw:
+            raw = player.get("title")
+        if raw and raw in device_names:
+            return device_names[raw]
+        return raw
 
     if video is not None:
-        title = video.get("title") or "?"
-        year = video.get("year") or ""
+        year = video.get("year") or video.get("parentYear") or ""
         offset = int(video.get("viewOffset") or 0)
         part = video.find("./Media/Part")
         srt_text = None
@@ -152,7 +197,18 @@ def now_playing(server: str, token: str):
             if media_file:
                 srt_path = find_srt(media_file)
                 if srt_path:
-                    srt_text = srt_context(srt_path, offset)
+                    srt_text = srt_context(srt_path, offset, current_only)
+
+        if video.get("type") == "episode":
+            show = video.get("grandparentTitle") or "?"
+            season = video.get("parentIndex")
+            episode = video.get("index")
+            se = f"s{int(season):02d}e{int(episode):02d}" if season and episode else ""
+            ep_title = video.get("title") or ""
+            display = f"{show} {se} - {ep_title}".strip() if ep_title else f"{show} {se}".strip()
+            return {"kind": "video", "title": display, "year": year, "ts": fmt_ts(offset), "line": srt_text, "device": device_name(video)}
+
+        title = video.get("title") or "?"
         return {"kind": "video", "title": title, "year": year, "ts": fmt_ts(offset), "line": srt_text, "device": device_name(video)}
 
     if track is not None:
@@ -169,14 +225,17 @@ def now_playing(server: str, token: str):
 def main():
     ap = argparse.ArgumentParser(prog="hee-scrob")
     ap.add_argument("-server", default=DEFAULT_SERVER)
+    ap.add_argument("-current-only", action="store_true", help="only the exact-moment subtitle line, no before/after context")
     args = ap.parse_args()
 
     token = read_token()
     if not token:
         sys.exit(f"hee-scrob: no token -- set $PLEX_TOKEN or write one to {DEFAULT_TOKEN_FILE}")
 
+    device_names = read_device_names()
+
     try:
-        r = now_playing(args.server, token)
+        r = now_playing(args.server, token, device_names, args.current_only)
     except Exception as e:
         sys.exit(f"hee-scrob: fetch failed: {e}")
 

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -50,10 +50,10 @@ def read_token() -> str:
 
 
 def fmt_ts(ms: int) -> str:
-    s = ms // 1000
+    s = max(ms, 0) // 1000
     h, s = divmod(s, 3600)
     m, s = divmod(s, 60)
-    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+    return f"{h:02d}:{m:02d}:{s:02d}"
 
 
 def _srt_dialogue(block: str, ts_re) -> str:
@@ -62,38 +62,48 @@ def _srt_dialogue(block: str, ts_re) -> str:
     return " ".join(dialogue).strip()
 
 
-def srt_line_at(srt_path: Path, offset_ms: int):
-    """Real SRT parse -- returns the subtitle text active at offset_ms,
-    quoted WITH real surrounding context (the block before and after),
-    not just the single isolated line -- a scrobble is a moment, not a
-    fragment."""
-    if not srt_path.exists():
-        return None
+def _srt_blocks(srt_path: Path):
     text = srt_path.read_text(errors="replace")
     ts_re = re.compile(
         r"(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})"
     )
-    blocks = text.split("\n\n")
-    for i, block in enumerate(blocks):
+    parsed = []
+    for block in text.split("\n\n"):
         m = ts_re.search(block)
         if not m:
             continue
         h1, m1, s1, ms1, h2, m2, s2, ms2 = map(int, m.groups())
         start = ((h1 * 3600 + m1 * 60 + s1) * 1000) + ms1
         end = ((h2 * 3600 + m2 * 60 + s2) * 1000) + ms2
+        parsed.append((start, end, _srt_dialogue(block, ts_re)))
+    return parsed, ts_re
+
+
+def srt_line_at_offset(blocks, offset_ms: int):
+    """Real, discrete lookup at one exact moment -- returns the real
+    dialogue active there, or None. No fabricated line when the moment
+    genuinely falls in a silent gap between subtitle blocks -- an
+    empty result there is correct, not a bug."""
+    for start, end, text in blocks:
         if start <= offset_ms <= end:
-            parts = []
-            if i > 0:
-                prev = _srt_dialogue(blocks[i - 1], ts_re)
-                if prev:
-                    parts.append(prev)
-            parts.append(_srt_dialogue(block, ts_re))
-            if i + 1 < len(blocks):
-                nxt = _srt_dialogue(blocks[i + 1], ts_re)
-                if nxt:
-                    parts.append(nxt)
-            return " / ".join(p for p in parts if p)
+            return text or None
     return None
+
+
+def srt_context(srt_path: Path, offset_ms: int):
+    """Real trigger: "need 00:00:00 for scrob and for tv/movie 5s
+    before, cur, 5s after, discrete things" -- three independent,
+    fixed-offset lookups (offset-5000, offset, offset+5000), not
+    whatever subtitle block happens to be structurally adjacent. Each
+    one is real and separately correct if empty."""
+    if not srt_path.exists():
+        return None
+    blocks, _ = _srt_blocks(srt_path)
+    before = srt_line_at_offset(blocks, offset_ms - 5000)
+    current = srt_line_at_offset(blocks, offset_ms)
+    after = srt_line_at_offset(blocks, offset_ms + 5000)
+    parts = [p for p in (before, current, after) if p]
+    return " / ".join(parts) if parts else None
 
 
 def find_srt(media_file: str):
@@ -142,7 +152,7 @@ def now_playing(server: str, token: str):
             if media_file:
                 srt_path = find_srt(media_file)
                 if srt_path:
-                    srt_text = srt_line_at(srt_path, offset)
+                    srt_text = srt_context(srt_path, offset)
         return {"kind": "video", "title": title, "year": year, "ts": fmt_ts(offset), "line": srt_text, "device": device_name(video)}
 
     if track is not None:

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -191,7 +191,7 @@ def main():
         print(f"np: {r['artist']} - {r['title']}{yr}{alb} @ {r['ts']}{dev}")
     else:
         yr = f" ({r['year']})" if r["year"] else ""
-        line = f' -- "{r["line"]}"' if r["line"] else ""
+        line = f' -- {r["line"]}' if r["line"] else ""
         print(f"np: {r['title']}{yr} @ {r['ts']}{line}{dev}")
 
 

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -56,8 +56,17 @@ def fmt_ts(ms: int) -> str:
     return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
 
 
+def _srt_dialogue(block: str, ts_re) -> str:
+    lines = block.strip().splitlines()
+    dialogue = [l for l in lines if l.strip() and not ts_re.search(l) and not l.strip().isdigit()]
+    return " ".join(dialogue).strip()
+
+
 def srt_line_at(srt_path: Path, offset_ms: int):
-    """Real SRT parse -- returns the subtitle text active at offset_ms, or None."""
+    """Real SRT parse -- returns the subtitle text active at offset_ms,
+    quoted WITH real surrounding context (the block before and after),
+    not just the single isolated line -- a scrobble is a moment, not a
+    fragment."""
     if not srt_path.exists():
         return None
     text = srt_path.read_text(errors="replace")
@@ -65,7 +74,7 @@ def srt_line_at(srt_path: Path, offset_ms: int):
         r"(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})"
     )
     blocks = text.split("\n\n")
-    for block in blocks:
+    for i, block in enumerate(blocks):
         m = ts_re.search(block)
         if not m:
             continue
@@ -73,10 +82,17 @@ def srt_line_at(srt_path: Path, offset_ms: int):
         start = ((h1 * 3600 + m1 * 60 + s1) * 1000) + ms1
         end = ((h2 * 3600 + m2 * 60 + s2) * 1000) + ms2
         if start <= offset_ms <= end:
-            lines = block.strip().splitlines()
-            # drop index + timestamp lines, keep the real dialogue text
-            dialogue = [l for l in lines if l.strip() and not ts_re.search(l) and not l.strip().isdigit()]
-            return " / ".join(dialogue).strip()
+            parts = []
+            if i > 0:
+                prev = _srt_dialogue(blocks[i - 1], ts_re)
+                if prev:
+                    parts.append(prev)
+            parts.append(_srt_dialogue(block, ts_re))
+            if i + 1 < len(blocks):
+                nxt = _srt_dialogue(blocks[i + 1], ts_re)
+                if nxt:
+                    parts.append(nxt)
+            return " / ".join(p for p in parts if p)
     return None
 
 

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -31,6 +31,21 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 DEFAULT_SERVER = "https://plex.crooked.tcos.us"
+DEFAULT_TOKEN_FILE = Path.home() / ".config" / "hee" / "plex-token"
+
+
+def read_token() -> str:
+    """Real fallback for EXEC-spawned shells: irssi's EXEC only inherits
+    env vars present when irssi itself launched, and doesn't source
+    .profile -- so PLEX_TOKEN set after the fact never reaches /SCROB
+    without a full session restart. A real file, checked second, avoids
+    needing one."""
+    env_token = os.environ.get("PLEX_TOKEN")
+    if env_token:
+        return env_token
+    if DEFAULT_TOKEN_FILE.exists():
+        return DEFAULT_TOKEN_FILE.read_text().strip()
+    return ""
 
 
 def fmt_ts(ms: int) -> str:
@@ -116,9 +131,9 @@ def main():
     ap.add_argument("-server", default=DEFAULT_SERVER)
     args = ap.parse_args()
 
-    token = os.environ.get("PLEX_TOKEN")
+    token = read_token()
     if not token:
-        sys.exit("hee-scrob: PLEX_TOKEN not set")
+        sys.exit(f"hee-scrob: no token -- set $PLEX_TOKEN or write one to {DEFAULT_TOKEN_FILE}")
 
     try:
         r = now_playing(args.server, token)

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""hee-scrob -- terse, punk-as-fuck now-playing scrobble, real Plex source.
+
+Real trigger (2026-08-22): "terse and hee and very spencer for when I
+/scrob in #tclug" -- fleet-ops#129's long-standing scrobbler gap
+finally getting built. Real Plex server: plex.crooked.tcos.us, docker
+on nuc-1. Then extended, same conversation: "song/show year, ts of
+point at scrobble and text (thousands of .srt files in media/) and
+cool short description and punk as fuck" -- for video content, pulls
+the real subtitle line active at the exact playback position from the
+real .srt sitting next to the media file. No invented dialogue --
+if there's no real .srt, there's no subtitle line in the output.
+
+Designed to be wired as an irssi alias that pipes stdout into a channel:
+  SCROB = "EXEC -o ~/.local/bin/hee-scrob"
+then just `/scrob` in the channel.
+
+Auth: reads PLEX_TOKEN from the environment -- never hardcoded, never
+printed. Real path once hee-cred (HEE#279) has it sealed:
+  hee cred -pass plex-token -exec hee-scrob
+
+Usage:
+  hee-scrob [-server URL]
+"""
+import argparse
+import os
+import re
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DEFAULT_SERVER = "https://plex.crooked.tcos.us"
+
+
+def fmt_ts(ms: int) -> str:
+    s = ms // 1000
+    h, s = divmod(s, 3600)
+    m, s = divmod(s, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+def srt_line_at(srt_path: Path, offset_ms: int):
+    """Real SRT parse -- returns the subtitle text active at offset_ms, or None."""
+    if not srt_path.exists():
+        return None
+    text = srt_path.read_text(errors="replace")
+    ts_re = re.compile(
+        r"(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})"
+    )
+    blocks = text.split("\n\n")
+    for block in blocks:
+        m = ts_re.search(block)
+        if not m:
+            continue
+        h1, m1, s1, ms1, h2, m2, s2, ms2 = map(int, m.groups())
+        start = ((h1 * 3600 + m1 * 60 + s1) * 1000) + ms1
+        end = ((h2 * 3600 + m2 * 60 + s2) * 1000) + ms2
+        if start <= offset_ms <= end:
+            lines = block.strip().splitlines()
+            # drop index + timestamp lines, keep the real dialogue text
+            dialogue = [l for l in lines if l.strip() and not ts_re.search(l) and not l.strip().isdigit()]
+            return " / ".join(dialogue).strip()
+    return None
+
+
+def find_srt(media_file: str):
+    p = Path(media_file)
+    for candidate in [p.with_suffix(".en.srt"), p.with_suffix(".srt")]:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def now_playing(server: str, token: str):
+    url = f"{server}/status/sessions?X-Plex-Token={token}"
+    req = urllib.request.Request(url, headers={"Accept": "application/xml"})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        body = r.read()
+    root = ET.fromstring(body)
+
+    video = root.find("Video")
+    track = root.find("Track")
+
+    def device_name(el):
+        player = el.find("Player")
+        return player.get("title") if player is not None else None
+
+    if video is not None:
+        title = video.get("title") or "?"
+        year = video.get("year") or ""
+        offset = int(video.get("viewOffset") or 0)
+        part = video.find("./Media/Part")
+        srt_text = None
+        if part is not None:
+            media_file = part.get("file")
+            if media_file:
+                srt_path = find_srt(media_file)
+                if srt_path:
+                    srt_text = srt_line_at(srt_path, offset)
+        return {"kind": "video", "title": title, "year": year, "ts": fmt_ts(offset), "line": srt_text, "device": device_name(video)}
+
+    if track is not None:
+        artist = track.get("grandparentTitle") or track.get("originalTitle") or "?"
+        title = track.get("title") or "?"
+        album = track.get("parentTitle") or ""
+        year = track.get("parentYear") or track.get("year") or ""
+        offset = int(track.get("viewOffset") or 0)
+        return {"kind": "track", "artist": artist, "title": title, "album": album, "year": year, "ts": fmt_ts(offset), "device": device_name(track)}
+
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="hee-scrob")
+    ap.add_argument("-server", default=DEFAULT_SERVER)
+    args = ap.parse_args()
+
+    token = os.environ.get("PLEX_TOKEN")
+    if not token:
+        sys.exit("hee-scrob: PLEX_TOKEN not set")
+
+    try:
+        r = now_playing(args.server, token)
+    except Exception as e:
+        sys.exit(f"hee-scrob: fetch failed: {e}")
+
+    if not r:
+        print("np: nothing. silence is punk too.")
+        return
+
+    dev = f" ({r['device']})" if r.get("device") else ""
+    if r["kind"] == "track":
+        yr = f" ({r['year']})" if r["year"] else ""
+        alb = f" [{r['album']}]" if r["album"] else ""
+        print(f"np: {r['artist']} - {r['title']}{yr}{alb} @ {r['ts']}{dev}")
+    else:
+        yr = f" ({r['year']})" if r["year"] else ""
+        line = f' -- "{r["line"]}"' if r["line"] else ""
+        print(f"np: {r['title']}{yr} @ {r['ts']}{line}{dev}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tooling/bin/hee-scrob
+++ b/tooling/bin/hee-scrob
@@ -25,6 +25,7 @@ Usage:
 import argparse
 import os
 import re
+import socket
 import sys
 import urllib.request
 import xml.etree.ElementTree as ET
@@ -98,8 +99,21 @@ def now_playing(server: str, token: str):
     track = root.find("Track")
 
     def device_name(el):
+        """Real hostname of the playing device, not just Plex's
+        self-reported friendly title -- reverse-DNS the Player's real
+        connecting IP first, fall back to the title Plex gives us if
+        that fails (most devices on this network won't have PTR
+        records, same real gap as everything else tonight)."""
         player = el.find("Player")
-        return player.get("title") if player is not None else None
+        if player is None:
+            return None
+        address = player.get("address")
+        if address:
+            try:
+                return socket.gethostbyaddr(address)[0]
+            except (socket.herror, socket.gaierror):
+                pass
+        return player.get("title")
 
     if video is not None:
         title = video.get("title") or "?"


### PR DESCRIPTION
Real trigger: fleet-ops#129's scrobbler gap + "terse and hee and very spencer for when I /scrob in #tclug." Song/show, year, real playback timestamp, real subtitle line at that position (never invented), device name. Honest gap noted in examples/hee-scrob-output.md: no PLEX_TOKEN here, live fetch not dogfooded end to end. Self-assigning per HEE Policy §10.