### PR TITLE
feat(doctrine): CRON-REAL-5 -- no pagers, ever

### DIFF
--- a/blueprints/spec-hee-cron-tooling-blueprint.yaml
+++ b/blueprints/spec-hee-cron-tooling-blueprint.yaml
@@ -24,6 +24,8 @@ guardrails:
     rule: "environment is explicit: PATH, HOME, SHELL, locale, tokens; no implicit shell profiles"
   - id: CRON-REAL-4
     rule: "output contract is append-only logs + structured artifacts; failures are edge-triggered alerts"
+  - id: CRON-REAL-5
+    rule: "no pagers, ever, cron or live human TTY alike: git/gh/man/etc. must run with paging forced off (GIT_PAGER=cat, GH_PAGER=cat, PAGER=cat, or the tool's own --no-pager flag). A tool silently blocking on a pager it never asked permission to invoke is the same failure class as an unguarded interactive prompt (see CRON-REAL-1) -- found live 2026-08-18 as a real gap this list didn't name explicitly."
 
 # Cron Wrappers Required
 cron_wrappers_required:

--- a/tools/sign-card.sh
+++ b/tools/sign-card.sh
@@ -17,6 +17,11 @@
 #   tools/sign-card.sh hee/cards/spencer-blank-generation-lyric.card.v1.yaml spencer inspector@tcos.us
 set -euo pipefail
 
+# CRON-REAL-5 (blueprints/spec-hee-cron-tooling-blueprint.yaml): no pagers,
+# ever -- a tool silently blocking on `less` is the same failure class as
+# an unguarded interactive prompt.
+export GIT_PAGER=cat PAGER=cat GH_PAGER=cat
+
 card_file="${1:?usage: sign-card.sh <card-file> <attestor-name> <gpg-key-id>}"
 attestor="${2:?usage: sign-card.sh <card-file> <attestor-name> <gpg-key-id>}"
 key_id="${3:?usage: sign-card.sh <card-file> <attestor-name> <gpg-key-id>}"


### PR DESCRIPTION
Real, previously-uncommitted work found during a cruft sweep -- CRON-REAL-5 (no pagers, cron or TTY alike, same failure class as CRON-REAL-1's unguarded interactive prompt) plus the first real fix applying it (tools/sign-card.sh).