### PR TITLE
fix(docs): HEE_POLICY.md was a bare placeholder, not a real redirect

### DIFF
--- a/docs/HEE_POLICY.md
+++ b/docs/HEE_POLICY.md
@@ -1,3 +1,7 @@
 # HEE Policy
 
-HEE-PLACEHOLDER
+This is the stable entrypoint document required by CI validation.
+
+Canonical policy lives at:
+
+- docs/doctrine/HEE_POLICY.md


### PR DESCRIPTION
Found live while sanity-checking content published to the new gopher docs site (man.tcos.us:7070). `docs/HEE_POLICY.md` was literally 30 bytes: "# HEE Policy\n\nHEE-PLACEHOLDER" -- never got the same real redirect-stub treatment `docs/HEE.md` already has. Real canonical content (511 lines) was fine the whole time at `docs/doctrine/HEE_POLICY.md`, just unreachable from the entrypoint path.