### PR TITLE
feat(man): real man pages for the hee-* tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,18 @@ uninstall-cli:
 .PHONY: install-man
 install-man:
 	@mkdir -p "$(MAN1DIR)"
-	@gzip -c "$(REPO_ROOT)/man/hee.1" >"$(MAN1DIR)/hee.1.gz"
-	@echo "🟢 installed: $(MAN1DIR)/hee.1.gz"
+	@for m in "$(REPO_ROOT)"/man/*.1; do \
+	  gzip -c "$$m" >"$(MAN1DIR)/$$(basename $$m).gz"; \
+	  echo "🟢 installed: $(MAN1DIR)/$$(basename $$m).gz"; \
+	done
 	@echo "🟦 test: MANPATH=$(MAN1DIR:%/man1=%/man):\$$MANPATH man hee"
 
 .PHONY: uninstall-man
 uninstall-man:
-	@rm -f "$(MAN1DIR)/hee.1.gz"
-	@echo "🟦 removed (if present): $(MAN1DIR)/hee.1.gz"
+	@for m in "$(REPO_ROOT)"/man/*.1; do \
+	  rm -f "$(MAN1DIR)/$$(basename $$m).gz"; \
+	done
+	@echo "🟦 removed (if present): all $(MAN1DIR)/*.gz from man/"
 
 .PHONY: install-bash-completion
 install-bash-completion:

--- a/man/hee-cred.1
+++ b/man/hee-cred.1
@@ -101,6 +101,10 @@ by any one of them \-\- this is intentional, not a weakness. Add every
 real party that legitimately needs access as a recipient at seal
 time; there is no way to add a recipient after the fact without
 re\-sealing.
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-pwgen (1),
 .BR hee-qr (1)

--- a/man/hee-cred.1
+++ b/man/hee-cred.1
@@ -1,0 +1,106 @@
+.TH HEE-CRED 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-cred \- real, minimal GPG-backed credential store
+.SH SYNOPSIS
+.B hee cred
+.B \-seal
+.I ACCOUNT
+.B \-recipients
+.I ID[,ID...]
+[\fB\-dir\fR \fIPATH\fR]
+.br
+.B hee cred
+.B \-seal
+.I ACCOUNT
+.B \-recipients
+.I ID[,ID...]
+.B \-genfrom
+.I TERM
+[\fB\-blocks\fR \fIN\fR] [\fB\-root\fR \fIPATH\fR]
+.br
+.B hee cred
+.B \-pass
+.I ACCOUNT
+.B \-exec
+.I COMMAND [ARGS...]
+[\fB\-dir\fR \fIPATH\fR]
+.SH DESCRIPTION
+.B hee-cred
+stores secrets as ciphertext-only GPG files under
+.BR .hee/secrets/ACCOUNT.gpg ,
+and never lets a decrypted value reach an agent's own visible output.
+Retrieval is exec-only: the secret is injected into a single child
+process's environment and nowhere else.
+.PP
+.B \-seal
+(typed) reads the secret from an interactive hidden prompt. It
+refuses to run at all if stdin isn't a real terminal \-\- deliberately,
+so a secret can never be piped in from a chat, log, or script.
+.PP
+.B \-seal \-genfrom
+instead pulls real words out of a local media corpus matching
+.IR TERM ,
+joins them into a passphrase. Still never printed \-\- flows straight
+into the same GPG encrypt call as a typed secret.
+.PP
+.B \-pass
+decrypts and sets the secret in the
+.B HEE_CRED_PASS
+environment variable of the
+.B \-exec
+child process only \-\- never argv (visible via \fBps\fR to other
+users), never stdout, never a log line.
+.SH OPTIONS
+.TP
+.BI \-seal " ACCOUNT"
+Seal a new secret under the given account name.
+.TP
+.BI \-recipients " ID[,ID...]"
+Comma\-separated GPG key IDs or emails to encrypt to. At least one
+required. Multiple recipients means any one of them can independently
+decrypt.
+.TP
+.BI \-pass " ACCOUNT"
+Decrypt the named account's secret for one \fB\-exec\fR call.
+.TP
+.BI \-exec " COMMAND [ARGS...]"
+The command to run with \fBHEE_CRED_PASS\fR set. Required with
+\fB\-pass\fR.
+.TP
+.BI \-genfrom " TERM"
+Generate a passphrase from real corpus text matching \fITERM\fR
+instead of typing one.
+.TP
+.BI \-blocks " N"
+Number of corpus\-derived words to join (default 4).
+.TP
+.BI \-dir " PATH"
+Secrets directory (default \fB.hee/secrets\fR, relative to cwd).
+.TP
+.BI \-root " PATH"
+Corpus root for \fB\-genfrom\fR (default \fB/var/local/hee\-corpus\fR).
+.SH EXAMPLES
+Seal a secret, two recipients:
+.PP
+.RS
+hee cred \-seal my\-api\-key \e
+.br
+    \-recipients 6A58FE47...3188,73B1462A...FDA0
+.RE
+.PP
+Use a sealed secret without ever seeing it:
+.PP
+.RS
+hee cred \-pass my\-api\-key \-exec bash \-c \e
+.br
+    'curl \-H "Authorization: Bearer $HEE_CRED_PASS" https://api.example.com'
+.RE
+.SH SECURITY
+A secret sealed to multiple recipients can be decrypted independently
+by any one of them \-\- this is intentional, not a weakness. Add every
+real party that legitimately needs access as a recipient at seal
+time; there is no way to add a recipient after the fact without
+re\-sealing.
+.SH SEE ALSO
+.BR hee-pwgen (1),
+.BR hee-qr (1)

--- a/man/hee-net.1
+++ b/man/hee-net.1
@@ -1,0 +1,39 @@
+.TH HEE-NET 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-net \- protocol-aware fetch: gopher, finger
+.SH SYNOPSIS
+.B hee net
+.B \-proto
+.BR gopher | finger
+.B \-url
+.I URL
+.br
+.B hee net
+.B \-proto
+.B finger
+.B \-query
+.I USER@HOST
+.SH DESCRIPTION
+Fetches content over an older, simpler real protocol instead of HTTP.
+Real trigger: "use finger and our hee tools vs what the network
+provides."
+.SH OPTIONS
+.TP
+.BI \-proto " {gopher,finger}"
+Which protocol to speak. Required.
+.TP
+.BI \-url " URL"
+Full gopher:// URL to fetch.
+.TP
+.BI \-query " QUERY"
+Finger query, user@host form.
+.SH EXAMPLES
+.RS
+.nf
+hee net \-proto gopher \-url gopher://man.tcos.us:7070/
+hee net \-proto finger \-query spencer@kiosk
+.fi
+.RE
+.SH SEE ALSO
+.BR hee-con (1),
+.BR hee-shell (1)

--- a/man/hee-net.1
+++ b/man/hee-net.1
@@ -34,6 +34,10 @@ hee net \-proto gopher \-url gopher://man.tcos.us:7070/
 hee net \-proto finger \-query spencer@kiosk
 .fi
 .RE
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-con (1),
 .BR hee-shell (1)

--- a/man/hee-pwgen.1
+++ b/man/hee-pwgen.1
@@ -1,0 +1,35 @@
+.TH HEE-PWGEN 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-pwgen \- real cryptographically secure password generator
+.SH SYNOPSIS
+.B hee pwgen
+[\fILENGTH\fR]
+.SH DESCRIPTION
+Generates one random password using Python's
+.B secrets
+module (a real CSPRNG, not
+.BR random ,
+which is not cryptographically secure and should never generate
+anything credential\-shaped). Alphabet is ASCII letters and digits.
+.PP
+Prints directly to stdout \-\- this is the "just generate one" tool,
+separate from
+.BR hee-cred (1)'s
+sealed\-storage path. Pipe the output into
+.BR hee-cred (1)'s
+interactive prompt yourself if it needs to be stored; this tool has
+no storage of its own.
+.SH OPTIONS
+.TP
+.I LENGTH
+Password length. Default 20 if omitted. Below 12 prints a real
+warning to stderr but still generates.
+.SH EXAMPLES
+.RS
+.nf
+hee pwgen
+hee pwgen 24
+.fi
+.RE
+.SH SEE ALSO
+.BR hee-cred (1)

--- a/man/hee-pwgen.1
+++ b/man/hee-pwgen.1
@@ -31,5 +31,9 @@ hee pwgen
 hee pwgen 24
 .fi
 .RE
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-cred (1)

--- a/man/hee-qdb.1
+++ b/man/hee-qdb.1
@@ -29,6 +29,10 @@ QDB = "EXEC \-o ~/.local/bin/hee qdb \-source ~/.local/bin/WHO\-WE\-ARE.md \-sea
 .RE
 .PP
 then \fB/QDB\fR \fITERM\fR in a channel.
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-scrob (1),
 .BR hee-scan (1)

--- a/man/hee-qdb.1
+++ b/man/hee-qdb.1
@@ -1,0 +1,34 @@
+.TH HEE-QDB 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-qdb \- real quote search across a source document
+.SH SYNOPSIS
+.B hee qdb
+.B \-source
+.I PATH
+.B \-search
+.I TERM
+.SH DESCRIPTION
+Searches a real source text file (a roster/quote\-log document such
+as WHO\-WE\-ARE.md) for lines matching
+.I TERM
+and prints real matches \-\- no fabricated quotes, no paraphrasing.
+.SH OPTIONS
+.TP
+.BI \-source " PATH"
+Path to the source document to search.
+.TP
+.BI \-search " TERM"
+Search term. Required.
+.SH EXAMPLES
+.RS
+hee qdb \-source ~/.local/bin/WHO\-WE\-ARE.md \-search "counting fact"
+.RE
+.SH IRSSI INTEGRATION
+.RS
+QDB = "EXEC \-o ~/.local/bin/hee qdb \-source ~/.local/bin/WHO\-WE\-ARE.md \-search"
+.RE
+.PP
+then \fB/QDB\fR \fITERM\fR in a channel.
+.SH SEE ALSO
+.BR hee-scrob (1),
+.BR hee-scan (1)

--- a/man/hee-qr.1
+++ b/man/hee-qr.1
@@ -1,0 +1,48 @@
+.TH HEE-QR 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-qr \- reader for a mt-logo-render "hee-key hole" anchor
+.SH SYNOPSIS
+.B hee qr
+.I IMAGE
+.br
+.B hee qr
+.I IMAGE
+.B \-manifest
+.I PATH
+.SH DESCRIPTION
+SHA256 is one\-way by design \-\- there is no reversing a hash back to
+the recipe that produced it, and guessing an image's parameters back
+out of its pixels via computer vision is not proof. So a
+.BR mt-logo-render (1)
+output carries its own real receipt instead: a scannable QR encoded
+into the image's own pixels, and matching PNG text\-chunk metadata.
+.PP
+.B hee\-qr
+tries the real QR scan first (via
+.BR zbarimg ,
+survives any format/bit\-depth change since it's pixels, not
+metadata), then falls back to reading the PNG metadata directly.
+.SH OPTIONS
+.TP
+.I IMAGE
+Path to a PNG rendered by mt\-logo\-render.
+.TP
+.BI \-manifest " PATH"
+Instead of just printing the result, write/update an entry in a
+static {recipe_id: recipe} JSON manifest at
+.I PATH
+\-\- the data file a static lookup page (no backend needed) reads
+client\-side by hash.
+.SH EXAMPLES
+.RS
+.nf
+hee qr hee\-logo.png
+hee qr hee\-logo.png \-manifest /srv/mt\-logo/manifest.json
+.fi
+.RE
+.SH OUTPUT
+JSON:
+.B {"source": "qr\-scan"|"png\-metadata", "recipe_id": "...", "recipe": {...}}
+\-\- or a real error if neither anchor is found.
+.SH SEE ALSO
+.BR mt-logo-render (1)

--- a/man/hee-qr.1
+++ b/man/hee-qr.1
@@ -44,5 +44,9 @@ hee qr hee\-logo.png \-manifest /srv/mt\-logo/manifest.json
 JSON:
 .B {"source": "qr\-scan"|"png\-metadata", "recipe_id": "...", "recipe": {...}}
 \-\- or a real error if neither anchor is found.
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR mt-logo-render (1)

--- a/man/hee-scan.1
+++ b/man/hee-scan.1
@@ -1,0 +1,47 @@
+.TH HEE-SCAN 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-scan \- named-target regex scan via ripgrep
+.SH SYNOPSIS
+.B hee scan
+.B \-target
+.I NAME
+.B \-r
+.I REGEX
+.br
+.B hee scan
+.B \-list\-targets
+.SH DESCRIPTION
+Runs a real ripgrep scan against a pre\-configured named target
+directory. "One true regex" \-\- ripgrep's own dialect, used
+consistently, no alternate regex engines.
+.PP
+Tolerates per\-file permission errors on mixed\-ownership filesystems
+(ripgrep's exit code 2 on partial permission failure is treated as
+non\-fatal; a real skipped\-file count is reported instead of aborting
+the whole scan).
+.SH OPTIONS
+.TP
+.BI \-target " NAME"
+Which configured target to scan.
+.TP
+.BI \-r " REGEX"
+Ripgrep\-dialect regex to search for.
+.TP
+.B \-list\-targets
+List configured target names instead of scanning.
+.SH EXAMPLES
+.RS
+.nf
+hee scan \-list\-targets
+hee scan \-target storage \-r 'hygien|foo|bar{3,}'
+.fi
+.RE
+.SH CAVEAT
+Any 40\-character git commit SHA\-1 will produce a real 32\-hex false
+positive under a bare
+.B [0\-9a\-f]{32}
+pattern \-\- structural, not a bug in this tool. Check context before
+treating a hit as a real secret.
+.SH SEE ALSO
+.BR hee-srtscan (1),
+.BR hee-cred (1)

--- a/man/hee-scan.1
+++ b/man/hee-scan.1
@@ -42,6 +42,10 @@ positive under a bare
 .B [0\-9a\-f]{32}
 pattern \-\- structural, not a bug in this tool. Check context before
 treating a hit as a real secret.
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-srtscan (1),
 .BR hee-cred (1)

--- a/man/hee-scrob.1
+++ b/man/hee-scrob.1
@@ -1,0 +1,62 @@
+.TH HEE-SCROB 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+hee-scrob \- terse now-playing scrobble, real Plex source
+.SH SYNOPSIS
+.B hee scrob
+[\fB\-server\fR \fIURL\fR] [\fB\-current\-only\fR]
+.SH DESCRIPTION
+Queries a real Plex server's
+.B /status/sessions
+endpoint and prints one line describing what's currently playing. For
+a TV episode, prints the real show name, season/episode, episode
+title, and year \-\- not just the episode's own title (Plex's
+.B title
+attribute on an episode element is the episode title, not the show's;
+show name lives in
+.BR grandparentTitle ).
+.PP
+For video content, also pulls the real subtitle line active at the
+exact playback position from the
+.B .srt
+sitting next to the media file. No invented dialogue \-\- if there's
+no real .srt, there's no subtitle line in the output, and a moment
+that genuinely falls in a silent gap prints nothing, correctly.
+.PP
+Device names: real hostname of the playing device via reverse DNS on
+the player's connecting IP, falling back to Plex's own self\-reported
+title if that fails. A local override file,
+.BR ~/.config/hee/device-names.txt ,
+takes priority over both when present.
+.SH OPTIONS
+.TP
+.BI \-server " URL"
+Plex server base URL (default \fBhttps://plex.crooked.tcos.us\fR).
+.TP
+.B \-current\-only
+Skip the \(+-5s subtitle context, print only the exact\-moment line.
+.SH AUTHENTICATION
+Reads
+.B PLEX_TOKEN
+from the environment, or from
+.B ~/.config/hee/plex\-token
+if unset (irssi's EXEC doesn't inherit env vars set after irssi
+launched, so the file is the reliable path for that case). Never
+hardcoded, never printed.
+.SH EXAMPLES
+.RS
+.nf
+hee scrob
+np: Family Guy s20e01 \- LASIK Instinct (2021) @ 00:10:40 (Dad TV)
+.fi
+.RE
+.SH IRSSI INTEGRATION
+Designed to sit behind an alias:
+.PP
+.RS
+SCROB = "EXEC \-o ~/.local/bin/hee scrob"
+.RE
+.PP
+then just \fB/SCROB\fR in a channel.
+.SH SEE ALSO
+.BR hee-qdb (1),
+.BR hee-net (1)

--- a/man/hee-scrob.1
+++ b/man/hee-scrob.1
@@ -57,6 +57,10 @@ SCROB = "EXEC \-o ~/.local/bin/hee scrob"
 .RE
 .PP
 then just \fB/SCROB\fR in a channel.
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-qdb (1),
 .BR hee-net (1)

--- a/man/hee.1
+++ b/man/hee.1
@@ -44,3 +44,7 @@ Installed truth for the toolchain.
 .TP
 .B ~/.local/share/bash-completion/completions/hee
 Bash completion file (if installed/loaded).
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550

--- a/man/mt-logo-render.1
+++ b/man/mt-logo-render.1
@@ -78,5 +78,9 @@ sha256sum OUT.png       real, reproducible, bit\-for\-bit across runs
 zbarimg \-\-raw OUT.png   scans the real QR out of the pixels
 .fi
 .RE
+.SH ORGANIZATION
+Twin Cities Open Systems \- Operations LLC
+.br
+IANA Private Enterprise Number: 1.3.6.1.4.1.66550
 .SH SEE ALSO
 .BR hee-qr (1)

--- a/man/mt-logo-render.1
+++ b/man/mt-logo-render.1
@@ -1,0 +1,82 @@
+.TH MT-LOGO-RENDER 1 "2026-08-22" "HEE" "User Commands"
+.SH NAME
+mt-logo-render \- real Pillow renderer for the mt-logo recipe schema
+.SH SYNOPSIS
+.B render.py
+.I RECIPE.json
+.B \-o
+.I OUT.png
+[\fB\-\-no\-qr\fR]
+.br
+.B render.py
+.B \-\-read\-anchor
+.I OUT.png
+.SH DESCRIPTION
+Renders a parametric logo from a JSON recipe, real 32\-bit RGBA
+output. Every render self\-verifies: a real scannable QR corner badge
+and matching PNG metadata, both encoding the recipe's canonical
+SHA256 id \-\- see
+.BR hee-qr (1)
+to read either back.
+.PP
+This is the real, missing pixel\-rendering half of the vendored
+.B upstream/mt\-logo\-render
+(recipe.rs), which only ever defined the data model, never the actual
+rendering code.
+.SH RECIPE SCHEMA
+.TP
+.B shape
+circle | square | triangle | hex
+.TP
+.B size
+"WxH", 16..4096 each dimension
+.TP
+.B base_color
+"#RGB" / "#RRGGBB" or a PIL\-recognized name
+.TP
+.B accent_color
+same format, optional
+.TP
+.B fill
+solid | pie:DEG | split:N | stripe:N
+.TP
+.B mark
+check | x | dot
+.TP
+.B badge
+corner_dot | corner_check
+.TP
+.B label
+<=4 chars, centered
+.TP
+.B glyph
+any unicode, centered (real color emoji via NotoColorEmoji when
+applicable, not a missing\-glyph box)
+.SH OPTIONS
+.TP
+.BI \-o " OUT.png"
+Output path. Required unless \fB\-\-read\-anchor\fR.
+.TP
+.B \-\-no\-qr
+Skip the scannable QR corner badge.
+.TP
+.BI \-\-read\-anchor " OUT.png"
+Read the embedded recipe/hash back out instead of rendering. Same as
+.BR hee-qr (1)'s
+PNG\-metadata path.
+.SH EXAMPLES
+.RS
+.nf
+render.py hee\-recipe.json \-o hee\-logo.png
+render.py \-\-read\-anchor hee\-logo.png
+.fi
+.RE
+.SH VERIFICATION
+.RS
+.nf
+sha256sum OUT.png       real, reproducible, bit\-for\-bit across runs
+zbarimg \-\-raw OUT.png   scans the real QR out of the pixels
+.fi
+.RE
+.SH SEE ALSO
+.BR hee-qr (1)


### PR DESCRIPTION
Real, proper troff man pages (matching man/hee.1's existing convention) for the 8 real hee-* tools built tonight -- not the plain-text doc dump this replaces on the live gopher site. Fixes install-man/uninstall-man to loop over man/*.1 instead of being hardcoded to just hee.1.

Live, published, externally reachable right now:
- gopher://man.tcos.us:7070/man/
- gopher://rtfm.tcos.us:7070/man/