### PR TITLE
feat(tooling): hee git merge -- interactive cross-repo mass-review tool

### DIFF
--- a/tooling/bin/hee
+++ b/tooling/bin/hee
@@ -13,6 +13,7 @@ hee — tiny router (POSIX sh)
 usage:
   hee lint [--mode warn|error]
   hee hooks install [--repo <path>]
+  hee git merge [-r <regex>] [--squash|--merge|--rebase] [--org <org>] [--author <login>]
   hee help
 
 design:
@@ -56,6 +57,19 @@ case "${cmd}" in
           *" --repo "*) exec "${TOOL_ROOT}/tooling/bin/hee-hooks-install" "$@" ;;
           *) exec "${TOOL_ROOT}/tooling/bin/hee-hooks-install" --repo "${TARGET_ROOT}" "$@" ;;
         esac
+        ;;
+      *)
+        usage
+        exit 0
+        ;;
+    esac
+    ;;
+  git)
+    sub="${1:-help}"
+    shift 2>/dev/null || true
+    case "${sub}" in
+      merge)
+        exec "${TOOL_ROOT}/tooling/bin/hee-git-merge" "$@"
         ;;
       *)
         usage

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""hee-git-merge: interactive, cross-repo mass-review-and-merge for open PRs.
+
+Real trigger (2026-08-22, Spencer): "need mass approve tool" +
+`./hee -git -merge -squash -r 'ready for me to mas merge regex'` +
+"and a one by one synopsis with y/N/s/Edit" -- a lot of PRs pile up
+across repos when an agent works fast; this is the human review gate,
+not a way to skip review. Default is always a one-by-one prompt, never
+a blind bulk merge.
+
+Usage:
+  hee-git-merge [-r REGEX] [--org ORG] [--author LOGIN] [--squash|--merge|--rebase]
+                [--delete-branch|--no-delete-branch]
+
+  -r REGEX          only show PRs whose title or body matches this
+                     (case-insensitive, Python re.search). Omit to see
+                     every open PR from --author across the org.
+  --org             GitHub org to search (default: Twin-Cities-Open-Systems)
+  --author          filter to PRs by this login (default: touchy-claude)
+  --squash          squash-merge on 'y' (default)
+  --merge           real merge commit on 'y' instead of squash
+  --rebase          rebase-merge on 'y' instead of squash
+  --delete-branch   delete the head branch after merge (default: on)
+  --no-delete-branch
+
+Per PR, prompts:
+  y  merge it now, this method
+  N  skip (default -- just hit enter)
+  s  skip (explicit, same as N)
+  e  show the full diff (gh pr diff), then re-prompt the same PR
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+def gh_json(args):
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        print(f"gh {' '.join(args)} failed:\n{proc.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(proc.stdout)
+
+
+def fetch_prs(org, author):
+    # gh search prs only supports a limited field set (no additions/
+    # changedFiles/statusCheckRollup) -- use it for discovery, then
+    # gh pr view per-repo for the richer synopsis fields.
+    return gh_json([
+        "search", "prs",
+        f"--owner={org}",
+        f"--author={author}",
+        "--state=open",
+        "--json=number,title,body,url,repository",
+        "--limit=100",
+    ])
+
+
+def fetch_pr_detail(repo_full, number):
+    try:
+        return gh_json([
+            "pr", "view", str(number), "--repo", repo_full,
+            "--json=additions,deletions,changedFiles,statusCheckRollup",
+        ])
+    except SystemExit:
+        return {}
+
+
+def matches(pr, pattern):
+    if pattern is None:
+        return True
+    hay = f"{pr.get('title', '')}\n{pr.get('body', '')}"
+    return bool(re.search(pattern, hay, re.IGNORECASE))
+
+
+def checks_summary(pr):
+    rollup = pr.get("statusCheckRollup") or []
+    if not rollup:
+        return "no checks"
+    states = [c.get("conclusion") or c.get("state") or "?" for c in rollup]
+    if all(s in ("SUCCESS", "success") for s in states):
+        return f"checks: {len(states)} passing"
+    if any(s in ("FAILURE", "failure", "ERROR", "error") for s in states):
+        return f"checks: FAILING ({states.count('FAILURE') + states.count('failure')} of {len(states)})"
+    return f"checks: {len(states)} pending/mixed"
+
+
+def print_synopsis(pr, repo_full):
+    print()
+    print(f"[{repo_full}#{pr['number']}] {pr['title']}")
+    print(f"  {pr['url']}")
+    print(f"  +{pr.get('additions', '?')} -{pr.get('deletions', '?')}  "
+          f"{pr.get('changedFiles', '?')} files  {checks_summary(pr)}")
+    body = (pr.get("body") or "").strip().splitlines()
+    if body:
+        print(f"  {body[0][:100]}")
+
+
+def do_merge(repo_full, number, method, delete_branch):
+    args = ["pr", "merge", str(number), "--repo", repo_full, f"--{method}"]
+    if delete_branch:
+        args.append("--delete-branch")
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode == 0:
+        print(f"  merged ({method}).")
+    else:
+        print(f"  MERGE FAILED:\n{proc.stderr}")
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="hee-git-merge")
+    ap.add_argument("-r", "--regex", default=None)
+    ap.add_argument("--org", default="Twin-Cities-Open-Systems")
+    ap.add_argument("--author", default="touchy-claude")
+    method = ap.add_mutually_exclusive_group()
+    method.add_argument("--squash", action="store_const", dest="method", const="squash")
+    method.add_argument("--merge", action="store_const", dest="method", const="merge")
+    method.add_argument("--rebase", action="store_const", dest="method", const="rebase")
+    ap.set_defaults(method="squash")
+    delbranch = ap.add_mutually_exclusive_group()
+    delbranch.add_argument("--delete-branch", action="store_true", dest="delete_branch")
+    delbranch.add_argument("--no-delete-branch", action="store_false", dest="delete_branch")
+    ap.set_defaults(delete_branch=True)
+    args = ap.parse_args()
+
+    prs = fetch_prs(args.org, args.author)
+    candidates = [pr for pr in prs if matches(pr, args.regex)]
+
+    if not candidates:
+        print(f"No open PRs from {args.author} in {args.org}"
+              + (f" matching /{args.regex}/" if args.regex else "") + ".")
+        return
+
+    print(f"{len(candidates)} candidate PR(s), method={args.method}, "
+          f"delete-branch={'yes' if args.delete_branch else 'no'}.")
+
+    for pr in candidates:
+        repo_full = pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository")
+        pr.update(fetch_pr_detail(repo_full, pr["number"]))
+        while True:
+            print_synopsis(pr, repo_full)
+            choice = input("  y/N/s/e > ").strip().lower()
+            if choice == "y":
+                do_merge(repo_full, pr["number"], args.method, args.delete_branch)
+                break
+            elif choice == "e":
+                subprocess.run(["gh", "pr", "diff", str(pr["number"]), "--repo", repo_full])
+                continue
+            else:
+                print("  skipped.")
+                break
+
+
+if __name__ == "__main__":
+    main()

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -44,6 +44,28 @@ Per PR, prompts:
 
 Already-APPROVED PRs are skipped automatically under --action=approve
 -- shown with a note, never re-prompted, never re-approved.
+
+Real extension (2026-08-23): "research if we already have tooling to
+merge these per your order. the tooling should be upgraded to do the
+order (like you just did here)" -- prompted by manually ordering 29
+real PRs by hand (fleet-ops#247) before this tool could do it. Real
+dependency detection, two layers, both real signal not guesses:
+
+  1. Explicit body text: "depends on #N" / "blocked by #N" /
+     "requires #N" / "needs #N" / "builds on #N" / "after #N" -- hard
+     edge, N merges first.
+  2. Same-repo content heuristic: if PR B's diff *text* contains the
+     basename of a file PR A's diff *adds*, B depends on A. Real case
+     this catches automatically that #1 alone wouldn't: HEE#298
+     (hee-ssh-send-keys) never says "depends on #279" anywhere in its
+     body, but its code contains the literal string "hee-cred" (calls
+     find_tool("hee-cred")), which is exactly the file HEE#279 adds --
+     caught by grep, not asserted.
+
+Falls back to (repo, PR number ascending) as the stable default/
+tiebreaker wherever no real edge exists. Cross-repo edges aren't
+attempted -- different repos' history is independent, ordering across
+them is cosmetic only.
 """
 import argparse
 import json
@@ -89,6 +111,109 @@ def matches(pr, pattern):
         return True
     hay = f"{pr.get('title', '')}\n{pr.get('body', '')}"
     return bool(re.search(pattern, hay, re.IGNORECASE))
+
+
+DEP_RE = re.compile(
+    r"(?:depends on|blocked by|requires|needs|builds on|build on|after)\s+#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def explicit_deps(pr):
+    """Real dependency numbers stated in the PR's own body -- returns a
+    set of PR numbers this PR must merge after."""
+    body = pr.get("body") or ""
+    return {int(n) for n in DEP_RE.findall(body)}
+
+
+def content_deps(candidates, repo_full):
+    """Real, generic same-repo heuristic: PR B depends on PR A if A's
+    diff adds a file whose basename appears as a literal string in B's
+    diff. Only runs within one repo -- cross-repo text overlap isn't a
+    real signal."""
+    same_repo = [pr for pr in candidates
+                 if (pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository")) == repo_full]
+    if len(same_repo) < 2:
+        return {}
+
+    added_files = {}   # pr number -> set of basenames this PR adds
+    diffs = {}          # pr number -> full diff text
+    for pr in same_repo:
+        num = pr["number"]
+        files_proc = subprocess.run(
+            ["gh", "pr", "view", str(num), "--repo", repo_full, "--json=files"],
+            capture_output=True, text=True,
+        )
+        basenames = set()
+        if files_proc.returncode == 0:
+            try:
+                files = json.loads(files_proc.stdout).get("files", [])
+                basenames = {f["path"].rsplit("/", 1)[-1] for f in files
+                             if f.get("additions", 0) > 0 and f.get("deletions", 0) == 0}
+            except (json.JSONDecodeError, KeyError):
+                pass
+        added_files[num] = basenames
+
+        diff_proc = subprocess.run(
+            ["gh", "pr", "diff", str(num), "--repo", repo_full],
+            capture_output=True, text=True,
+        )
+        diffs[num] = diff_proc.stdout if diff_proc.returncode == 0 else ""
+
+    deps = {pr["number"]: set() for pr in same_repo}
+    for b in same_repo:
+        bn = b["number"]
+        for a in same_repo:
+            an = a["number"]
+            if an == bn:
+                continue
+            for basename in added_files.get(an, ()):
+                if len(basename) > 3 and basename in diffs.get(bn, ""):
+                    deps[bn].add(an)
+                    break
+    return deps
+
+
+def order_candidates(candidates):
+    """Real topological sort: explicit body-text deps first, then the
+    same-repo content heuristic, (repo, number) ascending as the stable
+    fallback wherever no real edge exists."""
+    by_num = {}
+    for pr in candidates:
+        repo_full = pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository")
+        pr["_repo_full"] = repo_full
+        by_num[pr["number"]] = pr
+
+    deps = {pr["number"]: explicit_deps(pr) for pr in candidates}
+
+    for repo_full in {pr["_repo_full"] for pr in candidates}:
+        for num, ds in content_deps(candidates, repo_full).items():
+            deps[num] |= ds
+
+    # only keep edges to PRs actually in this candidate set
+    for num in deps:
+        deps[num] = {d for d in deps[num] if d in by_num and d != num}
+
+    ordered = []
+    placed = set()
+    remaining = sorted(candidates, key=lambda p: (p["_repo_full"], p["number"]))
+    while remaining:
+        progressed = False
+        still = []
+        for pr in remaining:
+            if deps[pr["number"]] <= placed:
+                ordered.append(pr)
+                placed.add(pr["number"])
+                progressed = True
+            else:
+                still.append(pr)
+        remaining = still
+        if not progressed:
+            # real cycle or missing dep -- don't hang, fall back to stable order for the rest
+            ordered.extend(remaining)
+            break
+
+    return ordered
 
 
 def checks_summary(pr):
@@ -161,6 +286,8 @@ def main():
         print(f"No open PRs from {args.author} in {args.org}"
               + (f" matching /{args.regex}/" if args.regex else "") + ".")
         return
+
+    candidates = order_candidates(candidates)
 
     action_desc = f"method={args.method}, delete-branch={'yes' if args.delete_branch else 'no'}" \
         if args.action == "merge" else "approve only, no merge"

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""hee-git-merge: interactive, cross-repo mass-review-and-merge for open PRs.
+"""hee-git-merge: interactive, cross-repo mass-review-and-merge (or
+mass-approve) for open PRs.
 
 Real trigger (2026-08-22, Spencer): "need mass approve tool" +
 `./hee -git -merge -squash -r 'ready for me to mas merge regex'` +
@@ -8,8 +9,19 @@ across repos when an agent works fast; this is the human review gate,
 not a way to skip review. Default is always a one-by-one prompt, never
 a blind bulk merge.
 
+Real extension, same session: "can have mass stamp/approve tool too?"
+-- --action approve turns 'y' into a real `gh pr review --approve`
+instead of a merge. Also fixed a real, live-observed problem: Spencer
+had re-approved several PRs multiple times (GitHub's own UI doesn't
+clearly show "you already approved this" on reopen) -- real, wasted
+clicks, confirmed via `gh pr view --json reviews` (one PR had 4).
+Every synopsis now shows real reviewDecision, and already-APPROVED PRs
+auto-skip with a note instead of re-prompting, so this tool can't
+reproduce that same waste.
+
 Usage:
-  hee-git-merge [-r REGEX] [--org ORG] [--author LOGIN] [--squash|--merge|--rebase]
+  hee-git-merge [-r REGEX] [--org ORG] [--author LOGIN]
+                [--action merge|approve] [--squash|--merge|--rebase]
                 [--delete-branch|--no-delete-branch]
 
   -r REGEX          only show PRs whose title or body matches this
@@ -17,17 +29,21 @@ Usage:
                      every open PR from --author across the org.
   --org             GitHub org to search (default: Twin-Cities-Open-Systems)
   --author          filter to PRs by this login (default: touchy-claude)
-  --squash          squash-merge on 'y' (default)
+  --action          merge (default) or approve
+  --squash          squash-merge on 'y' when --action=merge (default)
   --merge           real merge commit on 'y' instead of squash
   --rebase          rebase-merge on 'y' instead of squash
   --delete-branch   delete the head branch after merge (default: on)
   --no-delete-branch
 
 Per PR, prompts:
-  y  merge it now, this method
+  y  do the configured action (merge or approve) now
   N  skip (default -- just hit enter)
   s  skip (explicit, same as N)
   e  show the full diff (gh pr diff), then re-prompt the same PR
+
+Already-APPROVED PRs are skipped automatically under --action=approve
+-- shown with a note, never re-prompted, never re-approved.
 """
 import argparse
 import json
@@ -62,7 +78,7 @@ def fetch_pr_detail(repo_full, number):
     try:
         return gh_json([
             "pr", "view", str(number), "--repo", repo_full,
-            "--json=additions,deletions,changedFiles,statusCheckRollup",
+            "--json=additions,deletions,changedFiles,statusCheckRollup,reviewDecision",
         ])
     except SystemExit:
         return {}
@@ -92,7 +108,8 @@ def print_synopsis(pr, repo_full):
     print(f"[{repo_full}#{pr['number']}] {pr['title']}")
     print(f"  {pr['url']}")
     print(f"  +{pr.get('additions', '?')} -{pr.get('deletions', '?')}  "
-          f"{pr.get('changedFiles', '?')} files  {checks_summary(pr)}")
+          f"{pr.get('changedFiles', '?')} files  {checks_summary(pr)}  "
+          f"review: {pr.get('reviewDecision') or 'NONE'}")
     body = (pr.get("body") or "").strip().splitlines()
     if body:
         print(f"  {body[0][:100]}")
@@ -109,11 +126,23 @@ def do_merge(repo_full, number, method, delete_branch):
         print(f"  MERGE FAILED:\n{proc.stderr}")
 
 
+def do_approve(repo_full, number):
+    proc = subprocess.run(
+        ["gh", "pr", "review", str(number), "--repo", repo_full, "--approve"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode == 0:
+        print("  approved.")
+    else:
+        print(f"  APPROVE FAILED:\n{proc.stderr}")
+
+
 def main():
     ap = argparse.ArgumentParser(prog="hee-git-merge")
     ap.add_argument("-r", "--regex", default=None)
     ap.add_argument("--org", default="Twin-Cities-Open-Systems")
     ap.add_argument("--author", default="touchy-claude")
+    ap.add_argument("--action", choices=["merge", "approve"], default="merge")
     method = ap.add_mutually_exclusive_group()
     method.add_argument("--squash", action="store_const", dest="method", const="squash")
     method.add_argument("--merge", action="store_const", dest="method", const="merge")
@@ -133,17 +162,31 @@ def main():
               + (f" matching /{args.regex}/" if args.regex else "") + ".")
         return
 
-    print(f"{len(candidates)} candidate PR(s), method={args.method}, "
-          f"delete-branch={'yes' if args.delete_branch else 'no'}.")
+    action_desc = f"method={args.method}, delete-branch={'yes' if args.delete_branch else 'no'}" \
+        if args.action == "merge" else "approve only, no merge"
+    print(f"{len(candidates)} candidate PR(s), action={args.action}, {action_desc}.")
 
+    skipped_approved = 0
     for pr in candidates:
         repo_full = pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository")
         pr.update(fetch_pr_detail(repo_full, pr["number"]))
+
+        # Real, live-observed problem this fixes: re-approving an already-
+        # approved PR is pure waste (GitHub's UI gives no clear signal it
+        # already happened). Never re-prompt for one under --action=approve.
+        if args.action == "approve" and pr.get("reviewDecision") == "APPROVED":
+            skipped_approved += 1
+            print(f"\n[{repo_full}#{pr['number']}] already approved -- skipping.")
+            continue
+
         while True:
             print_synopsis(pr, repo_full)
             choice = input("  y/N/s/e > ").strip().lower()
             if choice == "y":
-                do_merge(repo_full, pr["number"], args.method, args.delete_branch)
+                if args.action == "approve":
+                    do_approve(repo_full, pr["number"])
+                else:
+                    do_merge(repo_full, pr["number"], args.method, args.delete_branch)
                 break
             elif choice == "e":
                 subprocess.run(["gh", "pr", "diff", str(pr["number"]), "--repo", repo_full])
@@ -151,6 +194,9 @@ def main():
             else:
                 print("  skipped.")
                 break
+
+    if skipped_approved:
+        print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
"need mass approve tool" + \`./hee -git -merge -squash -r 'ready for me
to mas merge regex'\` + "a one by one synopsis with y/N/s/Edit."

\`hee git merge\`: searches the org for open PRs by a given author
(default touchy-claude), optionally filtered by a regex against
title+body, then walks them one at a time with a real synopsis
(+/- lines, files changed, CI check status, first line of body) and a
y/N/s/e prompt. \`e\` shows the full diff then re-prompts the same PR.
Always interactive -- never a blind bulk merge.

Wired in as \`hee git merge\`, matching the existing \`hee hooks install\`
two-word pattern rather than a new top-level \`hee-*\` entry point.

## Real bug caught testing it live
\`gh search prs --json\` doesn't support additions/changedFiles/
statusCheckRollup (smaller field set than \`gh pr view\`) -- fixed to use
search for discovery only, then a per-PR \`gh pr view\` for synopsis
detail.

## Test plan
- [x] \`hee git merge -r <regex>\` against real open PRs (resume#16,
  fleet-ops#240) -- correct synopsis data, correct regex filtering
- [x] \`e\` path -- shows real \`gh pr diff\` output, re-prompts correctly
- [x] survived one real, transient GitHub GraphQL API error during
  testing -- degraded gracefully (\`? files\`, \`no checks\`) instead of
  crashing
- [x] \`hee help\` still shows the new subcommand correctly
- [x] no merges were actually performed during testing -- every test
  run answered N/e, this needs a human at the keyboard to actually merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tVMcJAK7j2m3vUoqxteYY