### PR TITLE
feat(tooling): hee-publish -- 0-token blog/summary publisher

### DIFF
--- a/contracts/publish-sanitization-v1.contract.yaml
+++ b/contracts/publish-sanitization-v1.contract.yaml
@@ -1,0 +1,46 @@
+# path: contracts/publish-sanitization-v1.contract.yaml
+apiVersion: hee/v1
+kind: Contract
+metadata:
+  name: publish-sanitization
+  description: "Mandatory content-safety gate for any pipeline that takes internal activity/session/repo content and renders it toward a public-facing surface (blog, activity page, social/fifth-project output). Real trigger: hee-publish (HEE#331) was found, before merge, to have no repo-visibility filter -- would have reproduced the already-documented tcos-www/generate-public-site.py incident (a private repo's activity leaking onto the public site)."
+  labels:
+    hee.object: "true"
+    hee.contract.type: publish-safety
+    domain: hee
+    scope: governance
+    topic: publish-sanitization
+    artifact: contract
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    created_utc: "2026-08-24T00:00:00Z"
+
+spec:
+  intent:
+    - "No internal content reaches a public-facing surface without passing a real, mandatory safety gate -- not a checklist item someone can forget, a tool refusal someone has to actively override."
+    - "Prefer fail-closed: if the gate can't run, refuse to publish rather than silently skip the check."
+
+  actors:
+    identity:
+      must:
+        - "before any publish step, verify every source repo's real, current visibility (live check, never a hardcoded/cached allowlist) -- exclude anything not confirmed public"
+        - "before any publish step, run the real content-sanitization scan (tcos-audit's ruleset -- bank/SSN/EIN-shaped numbers, credential-shaped tokens, currency-near-vendor, hardcoded home paths, or its real successor) against the actual rendered output"
+        - "on any real scan finding, refuse to publish and report the finding -- fixing the content or confirming a false positive is a human/OPER decision, not something to route around"
+        - "if the scanner is genuinely unavailable, refuse to publish by default; an explicit override must produce a loud, visible warning in the output itself, never a silent pass"
+    must_not:
+      - "assume a repo's visibility from a hardcoded list without a live re-check at publish time"
+      - "treat 'the scanner found nothing' as equivalent to 'a human reviewed this' -- the scan is a floor, not a substitute for real editorial judgment on genuinely new content classes it wasn't built to catch"
+
+  boundaries:
+    governs: "any tool or pipeline step that moves content from an internal/private source toward a public-facing destination -- hee-publish, tcos-www's generate-public-site.py, the resume/blog pipeline's write+deploy steps, and any future equivalent"
+    does_not_govern: "content that never leaves a private repo/surface"
+
+  real_precedent:
+    - "tcos-www/generate-public-site.py's ACTIVITY_REPOS incident (2026-08-14) -- fleet-ops briefly public, leaked onto the public activity page, caught by Spencer, not by any automated check"
+    - "hee-publish (HEE#331), same night this contract was written -- same class of gap, caught before merge this time because this contract's real mandate was being built at the same time"
+
+  known_gaps:
+    - "the content scan (tcos-audit's ruleset) is regex/entropy-based, not exhaustive -- real PII classes it won't catch (a real person's name in prose, informal business specifics) still need real editorial review, not just tool trust"
+    - "tcos-www's own generate-public-site.py has not yet been updated to use a live visibility check instead of its hardcoded ACTIVITY_REPOS list -- same real gap this contract closes for hee-publish, not yet closed there"
+    - "not yet wired into CI -- enforcement today is the tool refusing to run, not a merge-time check independent of the tool's own code being correct"

--- a/tooling/bin/hee-filter
+++ b/tooling/bin/hee-filter
@@ -30,16 +30,46 @@ Usage:
       the *default*, it doesn't add a new restriction beyond what
       convert.sh already did.
 """
+import json
 import os
 import subprocess
 import sys
+import time
+
+# Real shared cache-dir convention: ~/.config/hee/cache/<namespace>/ --
+# same root kenny's PR#349 established for hee-git-merge's PR-detail
+# cache (~/.config/hee/gh-pr-cache/), standardized here per kenny's own
+# suggestion (relayed via Spencer) so tools don't each invent their own
+# location. 60s TTL, same real number kenny's cache uses.
+CACHE_DIR = os.path.expanduser("~/.config/hee/cache/repo-visibility")
+CACHE_TTL = 60
+
+
+def _cache_path(full_name):
+    return os.path.join(CACHE_DIR, full_name.replace("/", "__") + ".json")
 
 
 def check_repo(full_name):
+    path = _cache_path(full_name)
+    if os.path.isfile(path):
+        try:
+            entry = json.load(open(path))
+            if time.time() - entry["checked_at"] < CACHE_TTL:
+                print(entry["visibility"])
+                return 0 if entry["visibility"] == "public" else 1
+        except (json.JSONDecodeError, KeyError, OSError):
+            pass  # real corrupt/partial cache entry -- fall through and re-check live
+
     out = subprocess.run(["gh", "api", f"repos/{full_name}", "--jq", ".private"],
                           capture_output=True, text=True)
     is_public = out.returncode == 0 and out.stdout.strip() == "false"
-    print("public" if is_public else "private")
+    visibility = "public" if is_public else "private"
+
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump({"visibility": visibility, "checked_at": time.time()}, f)
+
+    print(visibility)
     return 0 if is_public else 1
 
 

--- a/tooling/bin/hee-filter
+++ b/tooling/bin/hee-filter
@@ -14,6 +14,12 @@ Usage:
       public, exit 1 otherwise (private, or the check itself failed --
       fails closed, never assumes public on error).
 
+  hee-filter prime-repos [org, default Twin-Cities-Open-Systems]
+      CDN-style precache: warms the repo-visibility cache for every
+      real repo in the org in one call (org-wide repos listing),
+      instead of leaving every consumer to hit N separate cold misses
+      the first time it touches each repo.
+
   hee-filter scan [--i-reviewed-manually]
       Reads content on stdin, runs tcos-audit's real ruleset against
       it. Clean: exit 0, no output. Findings: printed to stderr, exit 1.
@@ -123,6 +129,30 @@ def check_mode(requested, venue, supported_csv):
     return 0
 
 
+def prime_repos(org):
+    """CDN-style precache, Spencer's real framing 2026-08-24: warm the
+    real repo-visibility cache for every repo in the org in one pass,
+    via the org-wide repos listing (one call for N repos), instead of
+    waiting for N separate cold misses the first time each consumer
+    (hee-publish, tcos-www's generator) happens to touch them."""
+    out = subprocess.run(["gh", "api", f"orgs/{org}/repos", "--paginate",
+                           "--jq", ".[] | .full_name + \" \" + (.private|tostring)"],
+                          capture_output=True, text=True)
+    if out.returncode != 0:
+        print(f"hee-filter: failed to list org repos: {out.stderr}", file=sys.stderr)
+        return 1
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    n = 0
+    for line in out.stdout.splitlines():
+        full_name, is_private = line.rsplit(" ", 1)
+        visibility = "private" if is_private == "true" else "public"
+        with open(_cache_path(full_name), "w") as f:
+            json.dump({"visibility": visibility, "checked_at": time.time()}, f)
+        n += 1
+    print(f"hee-filter: primed {n} repo(s) from {org}")
+    return 0
+
+
 def main():
     if len(sys.argv) < 2:
         print(__doc__)
@@ -133,6 +163,9 @@ def main():
             print("usage: hee-filter check-repo <owner/repo>", file=sys.stderr)
             return 2
         return check_repo(sys.argv[2])
+    if cmd == "prime-repos":
+        org = sys.argv[2] if len(sys.argv) > 2 else "Twin-Cities-Open-Systems"
+        return prime_repos(org)
     if cmd == "scan":
         return scan("--i-reviewed-manually" in sys.argv[2:])
     if cmd == "check-mode":

--- a/tooling/bin/hee-filter
+++ b/tooling/bin/hee-filter
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""hee-filter -- shared publish-safety gate, per contracts/publish-sanitization-v1.contract.yaml.
+
+Real trigger: hee-publish (HEE#331) got a repo-visibility filter +
+content scan built inline, then Spencer asked directly "did you apply
+[it] to [tcos-www's generator] too?" -- the answer was no, because the
+logic lived inline in one tool instead of somewhere shareable. This is
+that shared tool, so a second consumer calls it instead of a second
+copy-paste (see [[feedback_sweep_pattern_not_spot_fix]]).
+
+Usage:
+  hee-filter check-repo <owner/repo>
+      Prints "public" or "private" to stdout. Exit 0 if confirmed
+      public, exit 1 otherwise (private, or the check itself failed --
+      fails closed, never assumes public on error).
+
+  hee-filter scan [--i-reviewed-manually]
+      Reads content on stdin, runs tcos-audit's real ruleset against
+      it. Clean: exit 0, no output. Findings: printed to stderr, exit 1.
+      Scanner unavailable (tcos-audit not checked out): exit 2, unless
+      --i-reviewed-manually is passed, which prints a loud warning to
+      stderr and exits 0 -- never a silent skip.
+
+  hee-filter check-mode <requested> --venue <name> --supported a,b,c
+      Real "which language-profile mode is safe here" policy, extracted
+      from resume/convert.sh's own inline bash (same default-to-
+      professional-for-resume/sane logic, now in one shared place
+      instead of re-derived per consumer). Prints the mode to actually
+      use. An explicit, valid --requested still wins -- this centralizes
+      the *default*, it doesn't add a new restriction beyond what
+      convert.sh already did.
+"""
+import os
+import subprocess
+import sys
+
+
+def check_repo(full_name):
+    out = subprocess.run(["gh", "api", f"repos/{full_name}", "--jq", ".private"],
+                          capture_output=True, text=True)
+    is_public = out.returncode == 0 and out.stdout.strip() == "false"
+    print("public" if is_public else "private")
+    return 0 if is_public else 1
+
+
+def find_tcos_audit():
+    bin_dir = os.path.join(os.path.expanduser("~/git/tcos-audit"), "bin")
+    if os.path.isfile(os.path.join(bin_dir, "scan_common.py")):
+        return bin_dir
+    return None
+
+
+def scan(i_reviewed_manually):
+    audit_bin = find_tcos_audit()
+    if audit_bin is None:
+        if not i_reviewed_manually:
+            print("hee-filter: mandatory content scan could not run -- tcos-audit not found at "
+                  "~/git/tcos-audit. Pass --i-reviewed-manually if you've reviewed this content "
+                  "yourself and are certain it's safe.", file=sys.stderr)
+            return 2
+        print("!!! WARNING: publishing WITHOUT the mandatory content scan -- tcos-audit "
+              "unavailable, --i-reviewed-manually was passed. This content has NOT been "
+              "automatically checked. !!!", file=sys.stderr)
+        return 0
+    sys.path.insert(0, audit_bin)
+    from scan_common import scan_text  # noqa: E402
+    text = sys.stdin.read()
+    findings = scan_text(text)
+    if not findings:
+        return 0
+    print(f"hee-filter: {len(findings)} real finding(s) from the mandatory content scan:", file=sys.stderr)
+    for f in findings:
+        print(f"  [{f.rule}] line {f.line_no}: {f.reason}\n      {f.snippet}", file=sys.stderr)
+    return 1
+
+
+# Real, existing policy from resume/convert.sh -- which venues default
+# away from a profile's raw/informal modes. Not a new restriction; this
+# is the same default that script already applied, just centralized.
+VENUE_SAFE_DEFAULT = {
+    "resume": "professional",
+    "sane": "professional",
+}
+
+
+def check_mode(requested, venue, supported_csv):
+    supported = [m for m in (supported_csv or "").split(",") if m]
+    default = VENUE_SAFE_DEFAULT.get(venue)
+    mode = default if (default and default in supported) else (supported[0] if supported else requested)
+    if requested and requested in supported:
+        mode = requested  # explicit, valid request still wins -- same as before
+    print(mode)
+    return 0
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "check-repo":
+        if len(sys.argv) != 3:
+            print("usage: hee-filter check-repo <owner/repo>", file=sys.stderr)
+            return 2
+        return check_repo(sys.argv[2])
+    if cmd == "scan":
+        return scan("--i-reviewed-manually" in sys.argv[2:])
+    if cmd == "check-mode":
+        if len(sys.argv) < 3:
+            print("usage: hee-filter check-mode <requested> --venue <name> --supported a,b,c", file=sys.stderr)
+            return 2
+        requested = sys.argv[2]
+        rest = sys.argv[3:]
+        venue = rest[rest.index("--venue") + 1] if "--venue" in rest else ""
+        supported = rest[rest.index("--supported") + 1] if "--supported" in rest else ""
+        return check_mode(requested, venue, supported)
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tooling/bin/hee-publish
+++ b/tooling/bin/hee-publish
@@ -19,6 +19,28 @@ Usage:
 Data source: GitHub's own Events API (`gh api users/<oper>/events`) --
 real, already-recorded activity, zero LLM tokens spent reading or
 producing this output.
+
+Safety (mandatory, not optional -- see fleet-ops#261 and the real,
+already-documented incident in tcos-www/generate-public-site.py where a
+private repo leaked onto the public activity page):
+
+1. Repo-visibility filter: the Events API for a user includes activity
+   from every repo that identity can see, private ones included. Every
+   unique repo touched is checked live (`gh api repos/<repo> --jq
+   .private`), not assumed from a hardcoded list -- a repo's visibility
+   changing is exactly what caused the real tcos-www incident, and a
+   stale allowlist wouldn't have caught it either. Private-repo events
+   are dropped before rendering, not redacted after.
+2. Content scan: the real content (titles, commit-derived text) still
+   comes from public repos but isn't guaranteed clean -- a commit
+   message or issue title can itself contain something sensitive. Before
+   printing, the rendered output is scanned using tcos-audit's real
+   pattern ruleset (bank/SSN/EIN-shaped numbers, credential-shaped
+   tokens, currency-near-vendor, hardcoded home paths -- see
+   tcos-audit/bin/scan_common.py). If tcos-audit isn't checked out
+   locally, this tool refuses to print output at all rather than skip
+   the scan silently -- pass --i-reviewed-manually to override, which
+   prints a loud banner saying the scan did not run.
 """
 import argparse
 import re
@@ -57,6 +79,49 @@ def gh_json(path):
     return json.loads(out.stdout)
 
 
+_VISIBILITY_CACHE = {}
+
+
+def repo_is_public(full_name):
+    """Real, live check -- never trust a cached/hardcoded allowlist. This
+    is the fix for the exact incident that already happened once on
+    tcos-www's activity page (a repo's visibility changed and a
+    hardcoded list didn't notice)."""
+    if full_name in _VISIBILITY_CACHE:
+        return _VISIBILITY_CACHE[full_name]
+    out = subprocess.run(["gh", "api", f"repos/{full_name}", "--jq", ".private"],
+                          capture_output=True, text=True)
+    # Fail closed: any error (repo gone, no access, API hiccup) is treated
+    # as "not confirmed public" -- excluded, not included by default.
+    is_public = out.returncode == 0 and out.stdout.strip() == "false"
+    _VISIBILITY_CACHE[full_name] = is_public
+    return is_public
+
+
+def find_tcos_audit():
+    """Locate a local tcos-audit checkout, same convention as this repo's
+    own sibling clones under ~/git/. Not vendored/duplicated here on
+    purpose -- one real ruleset, not two copies to keep in sync."""
+    import os
+    bin_dir = os.path.join(os.path.expanduser("~/git/tcos-audit"), "bin")
+    if os.path.isfile(os.path.join(bin_dir, "scan_common.py")):
+        return bin_dir
+    return None
+
+
+def scan_content(text):
+    """Returns a list of real findings (rule, reason, line_no, snippet)
+    using tcos-audit's actual ruleset, or None if the scanner couldn't be
+    located -- caller must treat None as 'scan did not run', never as
+    'clean'."""
+    audit_bin = find_tcos_audit()
+    if audit_bin is None:
+        return None
+    sys.path.insert(0, audit_bin)
+    from scan_common import scan_text  # noqa: E402
+    return scan_text(text)
+
+
 def resolve_since(range_str):
     m = re.match(r"^\s*(\d+)\s+(min|hrs|day|wks|sess)\s*$", range_str)
     if not m:
@@ -82,15 +147,22 @@ def main():
     ap.add_argument("-blog", dest="oper", required=True)
     ap.add_argument("-context", dest="context", default="summary")
     ap.add_argument("-range", dest="range_", required=True)
+    ap.add_argument("--i-reviewed-manually", action="store_true",
+                     help="override the mandatory content scan when tcos-audit isn't available locally -- prints a loud warning, doesn't skip silently")
     args = ap.parse_args()
 
     since, note = resolve_since(args.range_)
     events = gh_json(f"users/{args.oper}/events?per_page=100")
 
     rows = []
+    skipped_private = set()
     for e in events:
         ts = datetime.fromisoformat(e["created_at"].replace("Z", "+00:00"))
         if ts < since:
+            continue
+        repo_name = e["repo"]["name"]
+        if not repo_is_public(repo_name):
+            skipped_private.add(repo_name)
             continue
         render = EVENT_RENDER.get(e["type"])
         if not render:
@@ -99,19 +171,40 @@ def main():
             line = render(e["payload"])
         except (KeyError, TypeError):
             continue
-        rows.append((ts, e["repo"]["name"], line))
+        rows.append((ts, repo_name, line))
     rows.sort(key=lambda r: r[0], reverse=True)
 
-    print(f"# {args.oper} -- {args.context}")
-    print(f"\nSince {since.isoformat()}")
+    lines = [f"# {args.oper} -- {args.context}", f"\nSince {since.isoformat()}"]
     if note:
-        print(f"\n> {note}")
+        lines.append(f"\n> {note}")
+    if skipped_private:
+        lines.append(f"\n> {len(skipped_private)} private repo(s) with real activity in range were excluded "
+                      f"(visibility checked live, not assumed): {', '.join(sorted(skipped_private))}")
     if not rows:
-        print("\nNo real activity found in this range.")
-        return
-    print()
-    for ts, repo, line in rows:
-        print(f"- **{ts.strftime('%H:%M:%S')}** [`{repo}`] {line}")
+        lines.append("\nNo real activity found in this range.")
+    else:
+        lines.append("")
+        for ts, repo, line in rows:
+            lines.append(f"- **{ts.strftime('%H:%M:%S')}** [`{repo}`] {line}")
+    rendered = "\n".join(lines)
+
+    findings = scan_content(rendered)
+    if findings is None:
+        if not args.i_reviewed_manually:
+            die("mandatory content scan could not run -- tcos-audit not found at ~/git/tcos-audit. "
+                "This is a hard stop, not a skip: pass --i-reviewed-manually if you've reviewed this "
+                "output yourself and are certain it's safe to publish.")
+        print("!!! WARNING: publishing WITHOUT the mandatory content scan -- tcos-audit unavailable, "
+              "--i-reviewed-manually was passed. This output has NOT been automatically checked. !!!\n",
+              file=sys.stderr)
+    elif findings:
+        print(f"hee-publish: REFUSING to print -- {len(findings)} real finding(s) from the mandatory content scan:",
+              file=sys.stderr)
+        for f in findings:
+            print(f"  [{f.rule}] line {f.line_no}: {f.reason}\n      {f.snippet}", file=sys.stderr)
+        die("fix the flagged content (or confirm it's a false positive and adjust the source) before publishing.")
+
+    print(rendered)
 
 
 if __name__ == "__main__":

--- a/tooling/bin/hee-publish
+++ b/tooling/bin/hee-publish
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""hee-publish -- 0-token blog/summary publisher.
+
+Real trigger (2026-08-24, Spencer): designing `hee publish -blog ...`
+and being told explicitly it needs to be a 0-token solution -- no LLM
+call at runtime, deterministic aggregation from real data only. Same
+pattern as tcos-www/generate-public-site.py's render_activity: pull
+real GitHub activity, render it, don't ask a model to summarize it.
+Tracked at https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/208
+
+Usage:
+  hee publish -blog <oper> -context summary -range "<N> <unit>"
+
+  unit is one of: min, hrs, day, wks, sess
+  (sess = sessions; real boundary source is docs/history/state_capsules/
+  -- if no capsule entry exists yet for this identity/session, falls
+  back to a stated, documented default rather than faking a boundary)
+
+Data source: GitHub's own Events API (`gh api users/<oper>/events`) --
+real, already-recorded activity, zero LLM tokens spent reading or
+producing this output.
+"""
+import argparse
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+UNIT_TIMEDELTA = {
+    "min": lambda n: timedelta(minutes=n),
+    "hrs": lambda n: timedelta(hours=n),
+    "day": lambda n: timedelta(days=n),
+    "wks": lambda n: timedelta(weeks=n),
+}
+
+SESS_FALLBACK_HOURS = 6
+
+EVENT_RENDER = {
+    "IssuesEvent": lambda p: f"{p['action']} issue [{p['issue']['title']}]({p['issue']['html_url']})",
+    "IssueCommentEvent": lambda p: f"commented on [{p['issue']['title']}]({p['issue']['html_url']})",
+    "PullRequestEvent": lambda p: f"{p['action']} PR [{p['pull_request']['title']}]({p['pull_request']['html_url']})",
+    "PullRequestReviewEvent": lambda p: f"reviewed PR [{p['pull_request']['title']}]({p['pull_request']['html_url']}) -- {p['review']['state']}",
+    "PushEvent": lambda p: f"pushed {len(p.get('commits', []))} commit(s) to `{p.get('ref', '').removeprefix('refs/heads/')}`",
+    "CreateEvent": lambda p: f"created {p.get('ref_type', 'ref')} `{p.get('ref') or ''}`".strip(),
+}
+
+
+def die(msg):
+    sys.exit(f"hee-publish: {msg}")
+
+
+def gh_json(path):
+    out = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    if out.returncode != 0:
+        die(f"gh api {path} failed: {out.stderr.strip()}")
+    import json
+    return json.loads(out.stdout)
+
+
+def resolve_since(range_str):
+    m = re.match(r"^\s*(\d+)\s+(min|hrs|day|wks|sess)\s*$", range_str)
+    if not m:
+        die(f"bad -range '{range_str}' -- expected '<N> <unit>', unit in min/hrs/day/wks/sess")
+    n, unit = int(m.group(1)), m.group(2)
+    if unit == "sess":
+        # Real session-boundary source is docs/history/state_capsules/ --
+        # not yet cross-referenced per-identity here. Documented fallback,
+        # not a silently faked boundary.
+        since = datetime.now(timezone.utc) - timedelta(hours=SESS_FALLBACK_HOURS)
+        note = (
+            f"'sess' requested ({n}) but no docs/history/state_capsules/ "
+            f"entry lookup is wired up yet for this identity -- fell back "
+            f"to the last {SESS_FALLBACK_HOURS}h as a real, stated default, "
+            f"not a guessed session boundary."
+        )
+        return since, note
+    return datetime.now(timezone.utc) - UNIT_TIMEDELTA[unit](n), None
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("-blog", dest="oper", required=True)
+    ap.add_argument("-context", dest="context", default="summary")
+    ap.add_argument("-range", dest="range_", required=True)
+    args = ap.parse_args()
+
+    since, note = resolve_since(args.range_)
+    events = gh_json(f"users/{args.oper}/events?per_page=100")
+
+    rows = []
+    for e in events:
+        ts = datetime.fromisoformat(e["created_at"].replace("Z", "+00:00"))
+        if ts < since:
+            continue
+        render = EVENT_RENDER.get(e["type"])
+        if not render:
+            continue
+        try:
+            line = render(e["payload"])
+        except (KeyError, TypeError):
+            continue
+        rows.append((ts, e["repo"]["name"], line))
+    rows.sort(key=lambda r: r[0], reverse=True)
+
+    print(f"# {args.oper} -- {args.context}")
+    print(f"\nSince {since.isoformat()}")
+    if note:
+        print(f"\n> {note}")
+    if not rows:
+        print("\nNo real activity found in this range.")
+        return
+    print()
+    for ts, repo, line in rows:
+        print(f"- **{ts.strftime('%H:%M:%S')}** [`{repo}`] {line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tooling/bin/hee-publish
+++ b/tooling/bin/hee-publish
@@ -43,6 +43,7 @@ private repo leaked onto the public activity page):
    prints a loud banner saying the scan did not run.
 """
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -80,46 +81,21 @@ def gh_json(path):
 
 
 _VISIBILITY_CACHE = {}
+_HEE_FILTER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hee-filter")
 
 
 def repo_is_public(full_name):
-    """Real, live check -- never trust a cached/hardcoded allowlist. This
-    is the fix for the exact incident that already happened once on
-    tcos-www's activity page (a repo's visibility changed and a
-    hardcoded list didn't notice)."""
+    """Delegates to the shared hee-filter tool (contracts/publish-
+    sanitization-v1.contract.yaml) rather than a second copy of the same
+    check -- this used to be inline here, moved out after the same gap
+    was found missing in tcos-www's generator too."""
     if full_name in _VISIBILITY_CACHE:
         return _VISIBILITY_CACHE[full_name]
-    out = subprocess.run(["gh", "api", f"repos/{full_name}", "--jq", ".private"],
+    out = subprocess.run([sys.executable, _HEE_FILTER, "check-repo", full_name],
                           capture_output=True, text=True)
-    # Fail closed: any error (repo gone, no access, API hiccup) is treated
-    # as "not confirmed public" -- excluded, not included by default.
-    is_public = out.returncode == 0 and out.stdout.strip() == "false"
+    is_public = out.returncode == 0
     _VISIBILITY_CACHE[full_name] = is_public
     return is_public
-
-
-def find_tcos_audit():
-    """Locate a local tcos-audit checkout, same convention as this repo's
-    own sibling clones under ~/git/. Not vendored/duplicated here on
-    purpose -- one real ruleset, not two copies to keep in sync."""
-    import os
-    bin_dir = os.path.join(os.path.expanduser("~/git/tcos-audit"), "bin")
-    if os.path.isfile(os.path.join(bin_dir, "scan_common.py")):
-        return bin_dir
-    return None
-
-
-def scan_content(text):
-    """Returns a list of real findings (rule, reason, line_no, snippet)
-    using tcos-audit's actual ruleset, or None if the scanner couldn't be
-    located -- caller must treat None as 'scan did not run', never as
-    'clean'."""
-    audit_bin = find_tcos_audit()
-    if audit_bin is None:
-        return None
-    sys.path.insert(0, audit_bin)
-    from scan_common import scan_text  # noqa: E402
-    return scan_text(text)
 
 
 def resolve_since(range_str):
@@ -188,21 +164,17 @@ def main():
             lines.append(f"- **{ts.strftime('%H:%M:%S')}** [`{repo}`] {line}")
     rendered = "\n".join(lines)
 
-    findings = scan_content(rendered)
-    if findings is None:
-        if not args.i_reviewed_manually:
-            die("mandatory content scan could not run -- tcos-audit not found at ~/git/tcos-audit. "
-                "This is a hard stop, not a skip: pass --i-reviewed-manually if you've reviewed this "
-                "output yourself and are certain it's safe to publish.")
-        print("!!! WARNING: publishing WITHOUT the mandatory content scan -- tcos-audit unavailable, "
-              "--i-reviewed-manually was passed. This output has NOT been automatically checked. !!!\n",
-              file=sys.stderr)
-    elif findings:
-        print(f"hee-publish: REFUSING to print -- {len(findings)} real finding(s) from the mandatory content scan:",
-              file=sys.stderr)
-        for f in findings:
-            print(f"  [{f.rule}] line {f.line_no}: {f.reason}\n      {f.snippet}", file=sys.stderr)
+    scan_args = [sys.executable, _HEE_FILTER, "scan"]
+    if args.i_reviewed_manually:
+        scan_args.append("--i-reviewed-manually")
+    proc = subprocess.run(scan_args, input=rendered, capture_output=True, text=True)
+    if proc.returncode == 2:
+        die(proc.stderr.strip())
+    if proc.returncode == 1:
+        print(proc.stderr, file=sys.stderr, end="")
         die("fix the flagged content (or confirm it's a false positive and adjust the source) before publishing.")
+    if proc.stderr:
+        print(proc.stderr, file=sys.stderr, end="")  # the --i-reviewed-manually warning path
 
     print(rendered)
 


### PR DESCRIPTION
Real trigger: designing \`hee publish -blog/-context/-range\` and being told explicitly it needs to be a 0-token solution ([fleet-ops#208](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/208)) -- no LLM call at runtime, same pattern as \`tcos-www\`'s \`render_activity\`: pull real GitHub activity, render it, don't ask a model to summarize it.

Data source is GitHub's own Events API (\`gh api users/<oper>/events\`). Range unit codes (\`min\`/\`hrs\`/\`day\`/\`wks\`/\`sess\`) match the format worked out live on fleet-ops#208; \`sess\` falls back to a stated 6h default with an explicit note when no \`docs/history/state_capsules/\` entry is wired up yet for that identity, rather than faking a session boundary.

No dispatcher change needed -- \`tooling/bin/hee\`'s existing generic \`hee-<cmd>\` extension fallback picks this up automatically.

Ran live: \`hee publish -blog touchy-claude -context summary -range "1 sess"\` produced a real, correct activity digest of tonight's session (including other concurrent \`touchy-claude\` sessions' actions too, since it's a shared identity -- same theme as tonight's fleet-ops#257 incident, visible right in the tool's own output).