### PR TITLE
feat(security): add gitleaks pre-commit hook -- real secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,6 +125,16 @@ repos:
         args: ['-d', 'relaxed']
         files: '\.(yaml|yml)$'
 
+  # Real secret scanning -- fleet-ops#265, direct follow-on from
+  # fleet-ops#257 (real leaked-credential incident). hee-security-check
+  # above is a naive keyword grep, not equivalent to a real scanner --
+  # this is format-aware (GitHub PATs, AWS keys, etc.), not just
+  # word-matching. Free/open-source, per HEE_POLICY.md §14.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
 # Configuration for pre-commit
 default_stages: [pre-commit, pre-push]
 fail_fast: false


### PR DESCRIPTION
Real trigger: [fleet-ops#265](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/265), direct follow-on from [fleet-ops#257](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/257) (real leaked-credential incident this exact session). \`hee-security-check\` (checked directly) is a naive keyword grep (\`password|secret|key|token\`), not equivalent to a real scanner -- no entropy checking, no format-specific patterns for real credential shapes.

\`gitleaks\` v8.30.1 -- real, current upstream release, checked via \`gh api repos/gitleaks/gitleaks/releases/latest\` before pinning, not guessed. Free/open-source, per [HEE_POLICY.md §14](https://github.com/Twin-Cities-Open-Systems/human-execution-engine/pull/333).

**Verified live before committing, not just configured**: downloaded the real official release binary directly (official GitHub releases channel), ran it against a synthetic (randomly generated, non-real) GitHub PAT in the correct \`ghp_\` format -- correctly flagged:

\`\`\`
RuleID: "github-pat"
"Uncovered a GitHub Personal Access Token, potentially leading to
unauthorized repository access and sensitive content exposure."
\`\`\`

A clean file in the same test produced zero false positives. This is the exact credential class fleet-ops#257 was about.