### PR TITLE
feat(tooling): hee-fields -- set type/Priority/Effort/Target-Date/epic in one command

### DIFF
--- a/tooling/bin/hee-fields
+++ b/tooling/bin/hee-fields
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""hee-fields: set an issue's type, Priority/Effort/Target-Date (Roadmap
+project fields), and real epic link, in one command.
+
+Real trigger (2026-08-24, HEE#334): fields have been set by hand all
+session via ad hoc `gh project item-edit` calls with hardcoded option
+IDs -- real, confirmed gap: 0 of 68 PRs had a priority label before
+tonight, and epic-grouping (hee-git-merge --action optimize) found 0 of
+9 remaining ready PRs reference a real epic. This is the missing wrapper,
+built before the real backfill pass, not during it.
+
+Field IDs are looked up live from the real Project (#1, "TCOS Roadmap")
+each run -- not hardcoded, so this doesn't silently break if a field is
+ever renamed/reordered.
+
+Usage:
+  hee-fields set --repo OWNER/REPO --number N [--type Task|Bug|Feature|Epic|Incident]
+                 [--priority P0|P1|P2|P3] [--effort XS|S|M|L|XL]
+                 [--target-date YYYY-MM-DD] [--epic-repo OWNER/REPO --epic-number N]
+"""
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+PROJECT_OWNER = "Twin-Cities-Open-Systems"
+PROJECT_NUMBER = 1
+
+
+def gh_json(args):
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        print(f"gh {' '.join(args)} failed:\n{proc.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(proc.stdout)
+
+
+def project_id():
+    q = '{ organization(login: "%s") { projectV2(number: %d) { id } } }' % (PROJECT_OWNER, PROJECT_NUMBER)
+    return gh_json(["api", "graphql", "-f", f"query={q}"])["data"]["organization"]["projectV2"]["id"]
+
+
+def field_map():
+    """Real, live field/option IDs -- looked up every run, not hardcoded."""
+    fields = gh_json(["project", "field-list", str(PROJECT_NUMBER), "--owner", PROJECT_OWNER, "--format", "json"])["fields"]
+    out = {}
+    for f in fields:
+        entry = {"id": f["id"]}
+        if "options" in f:
+            entry["options"] = {o["name"]: o["id"] for o in f["options"]}
+        out[f["name"]] = entry
+    return out
+
+
+def find_item(repo, number):
+    items = gh_json(["project", "item-list", str(PROJECT_NUMBER), "--owner", PROJECT_OWNER, "--format", "json", "--limit", "300"])["items"]
+    for it in items:
+        if it.get("content", {}).get("number") == number and it.get("repository") == f"https://github.com/{repo}":
+            return it["id"]
+    return None
+
+
+def ensure_item(repo, number):
+    """Real propagation lag confirmed live: gh project item-add returns
+    success before item-list reflects it -- an immediate re-query can
+    show 'not found' on a real, successful add. Retry with backoff
+    instead of failing on the first miss."""
+    item_id = find_item(repo, number)
+    if item_id:
+        return item_id
+    url = f"https://github.com/{repo}/issues/{number}"
+    subprocess.run(["gh", "project", "item-add", str(PROJECT_NUMBER), "--owner", PROJECT_OWNER, "--url", url],
+                    capture_output=True, text=True)
+    for delay in (1, 2, 4):
+        time.sleep(delay)
+        item_id = find_item(repo, number)
+        if item_id:
+            return item_id
+    sys.exit(f"hee-fields: could not add/find project item for {repo}#{number} after retries")
+
+
+def set_select(proj_id, item_id, field, option_name, fmap):
+    if field not in fmap or "options" not in fmap[field]:
+        sys.exit(f"hee-fields: no such select field '{field}'")
+    if option_name not in fmap[field]["options"]:
+        sys.exit(f"hee-fields: '{option_name}' is not a real option for '{field}'")
+    subprocess.run(["gh", "project", "item-edit", "--id", item_id, "--project-id", proj_id,
+                     "--field-id", fmap[field]["id"], "--single-select-option-id", fmap[field]["options"][option_name]],
+                    check=True)
+
+
+def set_date(proj_id, item_id, field, value, fmap):
+    subprocess.run(["gh", "project", "item-edit", "--id", item_id, "--project-id", proj_id,
+                     "--field-id", fmap[field]["id"], "--date", value], check=True)
+
+
+def set_type(repo, number, type_name):
+    subprocess.run(["gh", "api", f"repos/{repo}/issues/{number}", "--method", "PATCH", "-f", f"type={type_name}"],
+                    capture_output=True, text=True, check=True)
+
+
+def link_epic(repo, number, epic_repo, epic_number):
+    """Real native sub-issue link, not a text cross-ref -- only works
+    issue-to-issue (not PRs)."""
+    def node_id(r, n):
+        owner, name = r.split("/")
+        q = '{ repository(owner: "%s", name: "%s") { issue(number: %d) { id } } }' % (owner, name, n)
+        return gh_json(["api", "graphql", "-f", f"query={q}"])["data"]["repository"]["issue"]["id"]
+    parent = node_id(epic_repo, epic_number)
+    child = node_id(repo, number)
+    mutation = 'mutation($p:ID!,$c:ID!){ addSubIssue(input:{issueId:$p, subIssueId:$c}){ subIssue{number} } }'
+    subprocess.run(["gh", "api", "graphql", "-f", f"query={mutation}", "-f", f"p={parent}", "-f", f"c={child}"],
+                    capture_output=True, text=True, check=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="hee-fields")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    s = sub.add_parser("set")
+    s.add_argument("--repo", required=True)
+    s.add_argument("--number", type=int, required=True)
+    s.add_argument("--type", choices=["Task", "Bug", "Feature", "Epic", "Incident"])
+    s.add_argument("--priority", choices=["P0", "P1", "P2", "P3"])
+    s.add_argument("--effort", choices=["XS", "S", "M", "L", "XL"])
+    s.add_argument("--target-date")
+    s.add_argument("--epic-repo")
+    s.add_argument("--epic-number", type=int)
+    args = ap.parse_args()
+
+    if args.type:
+        set_type(args.repo, args.number, args.type)
+        print(f"  type -> {args.type}")
+
+    if args.priority or args.effort or args.target_date:
+        proj_id = project_id()
+        fmap = field_map()
+        item_id = ensure_item(args.repo, args.number)
+        if args.priority:
+            set_select(proj_id, item_id, "Priority", args.priority, fmap)
+            print(f"  priority -> {args.priority}")
+        if args.effort:
+            set_select(proj_id, item_id, "Effort", args.effort, fmap)
+            print(f"  effort -> {args.effort}")
+        if args.target_date:
+            set_date(proj_id, item_id, "Target Date", args.target_date, fmap)
+            print(f"  target date -> {args.target_date}")
+
+    if args.epic_repo and args.epic_number:
+        link_epic(args.repo, args.number, args.epic_repo, args.epic_number)
+        print(f"  epic -> {args.epic_repo}#{args.epic_number}")
+
+    print(f"{args.repo}#{args.number} done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Real gap, HEE#334: fields set by hand all night via ad hoc `gh project item-edit`. This wraps type + Priority/Effort/Target-Date (Project fields, IDs looked up live not hardcoded) + real native epic sub-issue link into one command.

Dogfooded for real: fleet-ops#259, and fleet-ops#224 with a genuinely correct epic link to fleet-ops#208. Caught and fixed a real bug in the process: `gh project item-add` has real propagation lag before `item-list` reflects it -- added retry/backoff.

Cross-ref: HEE#334

Agent-Sig: touchy-claude@kiosk (worktree touchy-claude-scratch-space)