### PR TITLE
docs: promote opus + corpus to the canonical org glossary

### DIFF
--- a/hee/cards/hee-words.seed.card.v1.yaml
+++ b/hee/cards/hee-words.seed.card.v1.yaml
@@ -4,11 +4,27 @@ metadata:
   name: hee-words-seed
   ts_human: 2026-02-10_1851
 spec:
-  purpose: seed dictionary and thesaurus work; yaml first; render md via jinja later.
+  purpose: >-
+    seed dictionary and thesaurus work; yaml first, promote by direct edit to
+    the canonical target when a word is ready -- not a jinja render pipeline
+    (dropped 2026-08-24, legacy/bloat for current framework and strategies,
+    per spencer).
   words:
     opus:
       definition: generated outputs hierarchy and working surface for machine friends.
       note: place for rendered html, md, yaml, text, exif, img; grouped by cards, pills, contracts, plans, blueprints, evidence.
+    corpus:
+      definition: >-
+        the whole real body of what actually exists in a given repo (or,
+        extended, the org) -- source and generated content alike. distinct
+        from opus, which names the generated/rendered layer specifically: a
+        corpus is the larger whole an opus is rendered from and lives inside.
+      note: >-
+        real precedent is the CORPUS.md "what actually exists here" index
+        thesis -- currently repo-scoped and unproven by design (.github and
+        human-execution-engine only), see hee/cards/... promotion_note below.
+        status: thesis, not settled -- carried into the glossary promotion
+        with that framing intact, not upgraded to settled doctrine here.
     thesis:
       definition: a proposition set down; etymology note is recorded in prior q.
     thesaurus:
@@ -17,3 +33,20 @@ spec:
   dif:
     - split into dictionary and thesaurus hee-objs
     - add trace keys for each word
+  promoted:
+    opus:
+      target: Twin-Cities-Open-Systems/.github profile/GLOSSARY.md
+      promotion_note_2026_08_24: >-
+        promoted from this seed card to the canonical org glossary by direct
+        edit, per spencer's explicit direction -- confirmed .github as the
+        real, correct location (org's own README names profile/GLOSSARY.md
+        "the org's shared definitions/invariants"). mirrors the promotion
+        pattern in hee/registries/party-kind.registry.v1.yaml
+        (propose -> use -> promote via dedicated edit with inline note).
+    corpus:
+      target: Twin-Cities-Open-Systems/.github profile/GLOSSARY.md
+      promotion_note_2026_08_24: >-
+        promoted alongside opus, same ceremony -- carried in as thesis
+        status (not settled doctrine), matching the real CORPUS.md framing
+        already live in two open PRs. no term is active in the glossary
+        beyond what that file itself says, per the same registry precedent.


### PR DESCRIPTION
Companion to [.github#TBD] (opus + corpus land in the actual
`profile/GLOSSARY.md` there).

Real promotion ceremony for the two words, mirroring
`hee/registries/party-kind.registry.v1.yaml`'s established
propose -> use -> promote pattern:

- **opus** — already real, defined here. Marked promoted with an
  inline promotion_note.
- **corpus** — new entry, deliberately carried in as *thesis, not
  settled* — grounded in the real `CORPUS.md` index-file idea already
  sitting in two open PRs (`.github`#26, `human-execution-engine`#251),
  not invented fresh in this PR.

Also drops the "render md via jinja later" plan from the card's
purpose line — legacy/too much bloat for the current framework and
strategies, per Spencer. Promotion now happens by direct edit to the
canonical target file instead of a render pipeline.