### PR TITLE
fix(hee-fields): idempotent epic-link, don't crash the batch

### DIFF
--- a/hee/cards/hee-words.seed.card.v1.yaml
+++ b/hee/cards/hee-words.seed.card.v1.yaml
@@ -4,11 +4,27 @@ metadata:
   name: hee-words-seed
   ts_human: 2026-02-10_1851
 spec:
-  purpose: seed dictionary and thesaurus work; yaml first; render md via jinja later.
+  purpose: >-
+    seed dictionary and thesaurus work; yaml first, promote by direct edit to
+    the canonical target when a word is ready -- not a jinja render pipeline
+    (dropped 2026-08-24, legacy/bloat for current framework and strategies,
+    per spencer).
   words:
     opus:
       definition: generated outputs hierarchy and working surface for machine friends.
       note: place for rendered html, md, yaml, text, exif, img; grouped by cards, pills, contracts, plans, blueprints, evidence.
+    corpus:
+      definition: >-
+        the whole real body of what actually exists in a given repo (or,
+        extended, the org) -- source and generated content alike. distinct
+        from opus, which names the generated/rendered layer specifically: a
+        corpus is the larger whole an opus is rendered from and lives inside.
+      note: >-
+        real precedent is the CORPUS.md "what actually exists here" index
+        thesis -- currently repo-scoped and unproven by design (.github and
+        human-execution-engine only), see hee/cards/... promotion_note below.
+        status: thesis, not settled -- carried into the glossary promotion
+        with that framing intact, not upgraded to settled doctrine here.
     thesis:
       definition: a proposition set down; etymology note is recorded in prior q.
     thesaurus:
@@ -17,3 +33,20 @@ spec:
   dif:
     - split into dictionary and thesaurus hee-objs
     - add trace keys for each word
+  promoted:
+    opus:
+      target: Twin-Cities-Open-Systems/.github profile/GLOSSARY.md
+      promotion_note_2026_08_24: >-
+        promoted from this seed card to the canonical org glossary by direct
+        edit, per spencer's explicit direction -- confirmed .github as the
+        real, correct location (org's own README names profile/GLOSSARY.md
+        "the org's shared definitions/invariants"). mirrors the promotion
+        pattern in hee/registries/party-kind.registry.v1.yaml
+        (propose -> use -> promote via dedicated edit with inline note).
+    corpus:
+      target: Twin-Cities-Open-Systems/.github profile/GLOSSARY.md
+      promotion_note_2026_08_24: >-
+        promoted alongside opus, same ceremony -- carried in as thesis
+        status (not settled doctrine), matching the real CORPUS.md framing
+        already live in two open PRs. no term is active in the glossary
+        beyond what that file itself says, per the same registry precedent.

--- a/tooling/bin/hee-fields
+++ b/tooling/bin/hee-fields
@@ -116,8 +116,13 @@ def link_epic(repo, number, epic_repo, epic_number):
     parent = node_id(epic_repo, epic_number)
     child = node_id(repo, number)
     mutation = 'mutation($p:ID!,$c:ID!){ addSubIssue(input:{issueId:$p, subIssueId:$c}){ subIssue{number} } }'
-    subprocess.run(["gh", "api", "graphql", "-f", f"query={mutation}", "-f", f"p={parent}", "-f", f"c={child}"],
-                    capture_output=True, text=True, check=True)
+    proc = subprocess.run(["gh", "api", "graphql", "-f", f"query={mutation}", "-f", f"p={parent}", "-f", f"c={child}"],
+                           capture_output=True, text=True)
+    if proc.returncode != 0:
+        if "may only have one parent" in proc.stderr or "duplicate sub-issues" in proc.stderr:
+            print(f"  epic -> {epic_repo}#{epic_number} (already linked, idempotent)")
+            return
+        sys.exit(f"hee-fields: link_epic {repo}#{number} -> {epic_repo}#{epic_number} failed:\n{proc.stderr}")
 
 
 def apply_one(item, ctx):


### PR DESCRIPTION
Real crash during tonight's 21-item field backfill batch3: re-linking an already-linked sub-issue aborted the whole run. Now treats that GraphQL validation message as success. Verified against the real case (#256->#262) before treating it as benign.