### PR TITLE
feat(governance): recover + genericize real doctrine from tcos-plan-private

### DIFF
--- a/blueprints/kinship-membership-governance-v1.yaml
+++ b/blueprints/kinship-membership-governance-v1.yaml
@@ -1,0 +1,67 @@
+# path: blueprints/kinship-membership-governance-v1.yaml
+apiVersion: hee/v1
+kind: BlueprintDoctrine
+metadata:
+  name: kinship-membership-governance-v1
+  description: "Reusable pattern for governing a durable, multi-tier human membership structure (an immutable identity tier plus one or more earned tiers) where identity is explicitly separated from entitlement. Extracted and genericized 2026-08-24 from a real, private, org-specific family-governance DIF (tcos-plan-private) as part of the fleet-ops#272 recovery epic -- no real names or relationships were carried over, only the reusable governance shape. The original, org-specific instance stays private and unchanged."
+  labels:
+    hee.object: "true"
+    domain: hee
+    scope: fleet-ops
+    topic: kinship-membership-governance
+    artifact: blueprint
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    recovered_utc: "2026-08-24T00:00:00Z"
+    origin_note: "genericized from a private tcos-plan-private DIF pill; see fleet-ops#272"
+spec:
+  result: false
+  schema-version: 1
+  status: proposed
+
+  intent:
+    - "Govern a durable membership structure where one tier is immutable (identity by an unearnable criterion, e.g. birth) and other tiers are earned and revocable."
+    - "Separate identity from entitlement explicitly: belonging to the immutable tier never automatically grants benefits, access, or roles."
+    - "Apply the same rules to every human party without exception, including whoever authored the policy."
+
+  actors:
+    identity_tier: "the immutable-membership bucket -- admission criterion is fixed and unearnable (e.g. birth into it); this blueprint doesn't prescribe the criterion itself, only that it be fixed and disjoint from the earned tiers"
+    earned_tiers: "one or more non-immutable buckets, membership granted and revocable by an explicit process; buckets are mutually disjoint -- a party belongs to exactly one"
+    adjudicator: "whoever has authority to act on a grievous-action trigger; a single founder in the simple case, a defined body in the mature case"
+
+  model:
+    participation_state: ["active", "opted_out", "suspended", "disqualified"]
+    entitlements:
+      benefits: "profit share / distributions / grants / perks"
+      access: "systems / docs / internal comms"
+      roles: "voting / leadership / trusteeship / operational authority"
+    rule: "Identity != entitlement. Immutable-tier identity does not by itself imply benefits, access, or roles."
+
+  ceremony:
+    - step: opt_out
+      description: "any member of the immutable tier may opt out at any time"
+      exit_condition: "benefits=0, access=0, roles=ineligible; recorded with real, auditable evidence (who/when/how)"
+      invariant: "opt-out never removes the underlying immutable-tier identity, and never entitles future distributions from new ventures"
+    - step: re_entry
+      description: "a member who opted out may request re-entry"
+      exit_condition: "never automatic; eligibility/process is left to the adopting org's own DIF"
+    - step: grievous_action_trigger
+      description: "protect first, adjudicate second -- first credible sign of trouble triggers an immediate blanket lock (zero perms), not a deliberation period"
+      exit_condition: "access, benefits, and roles are all immediately suspended and an evidence trail is opened"
+      guard: "hardship_guard -- the lock must not cause undue hardship to dependents who are not themselves the subject of the action; specifics are left to the adopting org's own DIF"
+    - step: due_process
+      description: "lock first, then due process -- any outcome (timeboxed suspension, permanent disqualification, or external/legal action) requires real evidence and an auditable record"
+      exit_condition: "outcome recorded; no automatic reinstatement, and no identity-based override of an entitlement decision"
+
+  invariants:
+    - "universality: policies apply to every human party without exception, including the policy's own author."
+    - "buckets_disjoint: a person belongs to exactly one tier at a time; no duplication across tiers."
+    - "identity_immutable: the immutable tier's admission rule, once set, does not change to accommodate a specific case."
+    - "evidence_required: opt-out, re-entry, disqualification, and any ban/no-contact action all require real, auditable evidence -- not a verbal or undocumented record."
+    - "no_automatic_reinstatement: a suspended or disqualified party does not return to active status without a real, evidenced decision."
+
+  known_gaps:
+    - "the 'credible trigger' threshold for the grievous_action_trigger step is intentionally left to the adopting org -- this blueprint sets the shape (lock first, evidence, hardship guard), not the numeric bar."
+    - "the adjudicator role is a single founder in the originating org-specific instance; a mature multi-party adjudication body is named as a future direction there but not designed here."
+    - "not yet exercised end-to-end as a real ceremony run -- the org-specific instance this was extracted from is itself still mid-DIF, per fleet-ops#272."

--- a/blueprints/org-foundation-design-v1.yaml
+++ b/blueprints/org-foundation-design-v1.yaml
@@ -1,0 +1,53 @@
+# path: blueprints/org-foundation-design-v1.yaml
+apiVersion: hee/v1
+kind: BlueprintDoctrine
+metadata:
+  name: org-foundation-design-v1
+  description: "Reusable design ceremony for laying out a durable organization's founding pillars, business model, and initial multi-entity structure before any filing happens. Extracted and genericized 2026-08-24 from a real, private, org-specific foundation/newco-formation DIF pair (tcos-plan-private) as part of the fleet-ops#272 recovery epic -- the actual pillar names, entity names, and identifiers were not carried over, only the reusable design shape. The original, org-specific instance stays private and unchanged."
+  labels:
+    hee.object: "true"
+    domain: hee
+    scope: fleet-ops
+    topic: org-foundation-design
+    artifact: blueprint
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    recovered_utc: "2026-08-24T00:00:00Z"
+    origin_note: "genericized from a private tcos-plan-private DIF pair; see fleet-ops#272"
+spec:
+  result: false
+  schema-version: 1
+  status: proposed
+
+  rules:
+    - "Design now; plan; verify; footgun-check; then plan execution -- in that order, never skipping ahead to execution."
+    - "No placeholders in the sense of silent gaps. An unresolved point is an explicit open_question, not a TBD left to rot."
+    - "Sensitive identifiers (tax IDs, legal entity numbers, etc.) are never invented or searched for speculatively -- they're supplied by a real human when the real filing happens, not designed around in advance."
+
+  intent:
+    endurance: "the organization is meant to outlast any single founder -- structure should harden toward that, not assume one person's continued involvement."
+    founder_note: "a founder originates roles/positions over time; the design should make that transition explicit rather than silently assume it never happens."
+
+  ceremony:
+    - step: name_the_pillars
+      description: "enumerate the organization's founding pillars -- the small number of things it exists to serve or protect. This blueprint doesn't prescribe what they are; only that each one gets a real definition, a stated reason it matters, and an explicit open_questions list."
+      exit_condition: "every pillar has: definition, why_it_matters, open_questions, and footguns"
+    - step: define_business_model
+      description: "state the model in one sentence, and the member/participant benefit modes (e.g. profit, learning, or a blend) -- explicit rather than assumed"
+      exit_condition: "a go/no-go rule exists for killing an underperforming venture, and a rule exists for how proceeds are allocated when one is sold"
+    - step: draft_entity_structure
+      description: "propose a candidate multi-entity structure (e.g. a top-level treasury/holding entity plus one or more operating/holding subsidiaries) -- explicitly a candidate to iterate, not a final answer"
+      exit_condition: "each entity has a stated role, and liability walls (what must never be co-mingled between entities) are named even if not yet finalized"
+    - step: dif_iterate
+      description: "iterate the whole draft against real open_questions and footguns until no silent gaps remain"
+      exit_condition: "every open_question is either answered or explicitly deferred with a named reason"
+
+  invariants:
+    - "design_precedes_execution: no filing, account-opening, or other execution step happens before this ceremony's draft_entity_structure and dif_iterate steps are both real, not stubbed."
+    - "no_silent_placeholders: every unresolved point is a named open_question, never a bare TBD with no owner."
+    - "identifiers_supplied_not_invented: real legal/tax identifiers come from the human running the ceremony when the real filing happens, never fabricated or guessed at design time."
+
+  known_gaps:
+    - "this blueprint captures the design ceremony's shape, not a template for what a good pillar list looks like -- the org-specific instance this was extracted from has its own real, private pillar list that isn't reproduced here."
+    - "not yet exercised end-to-end as a standalone ceremony run separate from the org-specific instance it was extracted from, which is itself still mid-DIF per fleet-ops#272."

--- a/contracts/tcos.mna.hee-sale-deal.contract.v1.yaml
+++ b/contracts/tcos.mna.hee-sale-deal.contract.v1.yaml
@@ -1,0 +1,70 @@
+apiVersion: hee/v1
+kind: Contract
+metadata:
+  name: tcos-mna-hee-sale-deal
+  description: "HEE asset transfer to TCOS with free-to-read covenant; governance + evidence + valuation method. Recovered from a private working repo (tcos-plan-private) 2026-08-24 and promoted here as the canonical copy -- see fleet-ops#272 for the recovery epic. Content unchanged from the original: contains no private identifiers, dollar figures, or personal names, so no sanitization was needed beyond the location move itself."
+  labels:
+    hee.object: "true"
+    domain: tcos
+    scope: mna
+    topic: hee-sale
+    artifact: contract
+  annotations:
+    inuid: "698e3412-47e8-832f-ad2d-25fb3c63f0af"
+    created_utc: "2026-02-13T07:59:53Z"
+    recovered_utc: "2026-08-24T00:00:00Z"
+spec:
+  intent:
+    - "TCOS must own HEE day-1 of TCOS FY2026 (target: 2026-03-01)."
+    - "HEE remains free-to-read forever; TCOS must never charge for access to read HEE."
+    - "This must not preclude TCOS from earning revenue from services/products built on HEE."
+  assets_transferred:
+    - id: hee-ip
+      includes:
+        - "copyright/IP in HEE authored by seller"
+        - "repo admin/control (GitHub org/user ownership + settings control)"
+      excludes:
+        - "third-party contributor IP not owned by seller (licensed per repo license)"
+    - id: hee-brand
+      status: "TBD"
+      includes:
+        - "trademark(s) (if/when filed) + assignment/recordation evidence"
+        - "domains/social handles (if any) + transfer evidence"
+  covenant_free_to_read:
+    must:
+      - "No paywall for reading HEE content."
+      - "License changes are protected actions (see governance)."
+    allowed_revenue:
+      - "support/consulting"
+      - "managed CI/gates + hosted tooling"
+      - "certification/audits"
+      - "implementation services (margin expansion as a service)"
+  governance:
+    protected_actions:
+      p0:
+        - "change license terms"
+        - "transfer trademark ownership"
+        - "transfer repo ownership to non-TCOS entity"
+        - "remove/disable validation gates in strict mode"
+    evidence_required:
+      - "written decision artifact (hee-obj) with inuid + timestamps"
+      - "signing evidence bundle (TBD) for real-world transactions"
+    note:
+      - "Use p-tiers (p0 highest) for authority limits; never 'benefits' language, use entitlements."
+  valuation_method:
+    rule:
+      - "All valuation claims must be explained in docs/math BEFORE being encoded into math/."
+    placeholder:
+      - "Replacement cost (cost-to-recreate) + adoption evidence + revenue channel option value."
+      - "Prefer milestone/earnout unlocks over big upfront numbers."
+  compliance_preflight:
+    must:
+      - "Securities attorney review before any investor money moves."
+      - "CPA/tax review for barter/meal compensation and related-party transfers."
+    reg_d:
+      - "Track 506(b)/506(c) decision as a hee-obj with evidence."
+  open_questions:
+    - "Trademark timing: file under TCOS entity vs personal + assignment later."
+    - "Entity routing: TCOS LLC vs Hold as the owning entity for HEE."
+    - "Cap table / units: LLC units vs corp shares; preferred/convertible instruments policy."
+    - "Define 'margin' measurement + audit method for margin-expansion service contracts."

--- a/contracts/treasury-invariants-v1.contract.yaml
+++ b/contracts/treasury-invariants-v1.contract.yaml
@@ -1,0 +1,69 @@
+apiVersion: hee/v1
+kind: Contract
+metadata:
+  name: treasury-invariants
+  description: "Generic reserve/float/instrument/priority-tier financial-controls contract. Extracted and genericized 2026-08-24 from a real, private, org-specific treasury DIF (tcos-plan-private) as part of the fleet-ops#272 recovery epic -- no dollar figures, entity names, or other private specifics were carried over, only the reusable control pattern. The original, org-specific instance stays private and unchanged; this is the public schema it can conform to."
+  labels:
+    hee.object: "true"
+    hee.contract.type: financial-controls
+    domain: hee
+    scope: governance
+    topic: treasury
+    artifact: contract
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    recovered_utc: "2026-08-24T00:00:00Z"
+    origin_note: "genericized from a private tcos-plan-private DIF pill; see fleet-ops#272"
+
+spec:
+  invariants:
+    - "No vibes, no 'just send it' -- every transfer is an explicit, named instrument."
+    - "Reserve and float are separate concepts and must be tracked separately from day 1."
+    - "Treasury controls apply to every human party, including any founder -- no exemptions."
+    - "Verified evidence is the model; important actions require auditable evidence, not just a record."
+
+  eli5:
+    reserve: "War chest. Not for daily spend. Strategic only."
+    float: "Operating cash. Used daily/weekly under a real budget."
+
+  cash_locations:
+    default_rule: "Reserve lives at the top-level entity. Subsidiary/operating entities hold float only."
+    note: "Exact entity mapping is org-specific -- left as an open_question for the adopting org's own DIF, not prescribed here."
+
+  allowed_transfer_instruments:
+    - "capital_contribution"
+    - "intercompany_loan"
+    - "service_fee"
+    - "lease_payment"
+    - "ip_license_fee"
+    - "distribution"
+
+  priority_tiers:
+    note: "p0 is highest priority. Record p-tier decisions even under a single-approver model, so the record survives a later move to delegated approval."
+    tiers:
+      - p: 0
+        label: "strategic"
+        rule: "Requires an explicit instrument type + real physical/auditable evidence + (optional) cooldown."
+      - p: 1
+        label: "material"
+        rule: "Requires an explicit note + evidence pointers."
+      - p: 2
+        label: "routine"
+        rule: "Within budget; record reason + category, no further gate."
+
+  drift_detection:
+    rule: "If expected artifacts are missing or stale, alert -- don't silently assume they're current."
+    freshness:
+      inputs: ["mtime_age", "git_touch_age"]
+      note: "Both signals are used; exact weighting/thresholds are left to the adopting org's own doc, not prescribed here."
+    expected_artifact_examples:
+      - "latest handoff/status record"
+      - "this contract's own most recent amendment"
+      - "evidence pointers for any strategic (p0) action"
+
+  open_questions_for_adopters:
+    - "Exact entity mapping for reserve/float across your own entity structure."
+    - "Real numeric thresholds for each priority tier, and currency handling."
+    - "How instruments are enforced mechanically -- ledger categories, approval workflow, or both."
+    - "Delegation model over time (who inherits approval authority, and when)."

--- a/docs/guides/HA_KIOSK_CRED_STORAGE.md
+++ b/docs/guides/HA_KIOSK_CRED_STORAGE.md
@@ -1,0 +1,61 @@
+# HA kiosk credential storage (low-value creds) — options + tradeoffs
+
+Recovered from a private working repo (`tcos-plan-private`) 2026-08-24 as
+part of the [fleet-ops#272](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/272)
+recovery epic. Generic sysadmin reference material -- no private content,
+migrated as-is.
+
+## Context
+Goal: kiosk-ish Home Assistant display on a Linux box. Need "it just loads"
+behavior with minimal future fuss. Credentials are low-value, but sane
+blast-radius still matters.
+
+## Best practical (recommended): don't store the password — store a session
+**Idea:** Use a dedicated HA "display/kiosk" user and rely on a persistent
+login session (cookie) in a dedicated browser profile.
+
+### Steps
+1. Home Assistant:
+   - Create a non-admin user: `display` / `kiosk`
+   - Give minimum privileges (at least: not admin)
+   - Set its default dashboard to the intended Lovelace view
+2. Kiosk box (Firefox recommended):
+   - Create a dedicated Firefox profile for HA kiosk (keeps cookies/session isolated)
+   - Log in once as the `display` user
+   - Enable "Keep me logged in / Remember me" (whatever the HA login flow offers)
+   - After that, the kiosk uses the stored session cookie instead of retyping a password
+
+### Why this is good
+- If the kiosk box is compromised, an attacker gets a "display user session," not admin creds.
+- Less password handling; fewer "where did I store it?" problems.
+- Clean separation if the same machine is used for other browsing.
+
+## Next best: store password in the browser password manager
+**Idea:** Let the browser save the password (convenient, usually fine for low-value creds).
+
+Pros: easiest UX; works across browser restarts even if the session cookie expires.
+
+Cons: anyone with access to the browser profile/home dir can often exfiltrate it (not plaintext, but not "safe" against a local attacker).
+
+Optional guardrail: a browser "primary password" adds friction (may be annoying for an unattended kiosk).
+
+## More "systems-y": OS keyring (mostly for Chrome-family browsers)
+Chrome/Chromium/Edge often integrate with GNOME Keyring/Secret Service.
+
+Pros: centralized credential store.
+
+Cons: on auto-login kiosks, keyring unlock behavior can be finicky unless intentionally configured.
+
+## Convenience-first (riskier): skip login via trusted network setup
+Some HA setups allow network-trusted access (e.g., from a specific IP/subnet).
+
+Pros: no credentials stored and no login prompts.
+
+Cons: anyone with access to that "trusted" network path may gain access. If used: pin to a single static IP, isolate VLAN, and treat it as a security-boundary decision.
+
+## Recommended plan for this shape of environment
+- Create an HA user: `display` (non-admin)
+- Use a dedicated browser profile for the kiosk
+- Log in once and keep the session persistent
+- Avoid admin creds on kiosk devices
+- Only consider trusted-network auth if you intentionally accept the risk and have network isolation

--- a/docs/guides/PDSH_SSH_PDCP_NOTES.md
+++ b/docs/guides/PDSH_SSH_PDCP_NOTES.md
@@ -1,0 +1,106 @@
+# PDSH + SSH keys + pdcp pitfalls (lab notes)
+
+Recovered from a private working repo (`tcos-plan-private`) 2026-08-24 as
+part of the [fleet-ops#272](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/272)
+recovery epic. Generic sysadmin reference material -- real internal
+hostnames/IPs from the original were replaced with placeholders
+(`host1`, `10.0.0.1`) below; everything else is unchanged.
+
+## Goal
+- Fan-out commands with `pdsh` over SSH from a box that does **not** run sshd.
+- Bootstrap SSH keys cleanly; avoid interactive prompts.
+- Copy small files (e.g., `~/.config/pdsh/hosts`) with `pdcp`.
+
+## Baseline setup (client-only)
+- Needs: `openssh-client`, `pdsh`
+- Verify SSH module: `pdsh -L` should show `Module: rcmd/ssh` and `Active: yes`
+
+## Key bootstrap
+### Preferred: ssh-copy-id
+- Standard: `ssh-copy-id -i ~/.ssh/id_ed25519.pub user@host1`
+- If local `~/.ssh/config` forces publickey and blocks password bootstrap, override:
+  `ssh-copy-id -i ~/.ssh/id_ed25519.pub -o PreferredAuthentications=password -o PubkeyAuthentication=no user@host1`
+
+### Bulletproof fallback: append via ssh
+- Create perms + append idempotently:
+  - `ssh user@host1 'umask 077; mkdir -p ~/.ssh; touch ~/.ssh/authorized_keys; chmod 700 ~/.ssh; chmod 600 ~/.ssh/authorized_keys'`
+  - `cat ~/.ssh/id_ed25519.pub | ssh user@host1 'grep -qxF "$(cat)" ~/.ssh/authorized_keys || cat >> ~/.ssh/authorized_keys'`
+
+## Triage notes (actual failures seen)
+### 1) "/usr/bin/sft: No such file or directory"
+- Cause: `~/.ssh/config` contained a ScaleFT `Match exec "/usr/bin/sft ..."` block, but `sft` was not installed.
+- Fix: guard the Match with a `test -x /usr/bin/sft && ...` so non-ScaleFT boxes do not blow up.
+
+### 2) ssh works with one target string, fails with another
+- Example: `ssh -l user 10.0.0.1 uptime` works, but `ssh-copy-id user@10.0.0.1 ...` fails.
+- Cause: different host string triggers different `~/.ssh/config` stanzas, different auth, or different ProxyCommand/Match behavior.
+- Fix: use the same host token that worked, or inspect:
+  `ssh -G user@host1 | egrep -i 'hostname|user|proxycommand|identityfile|preferredauthentications|pubkeyauthentication'`
+
+### 3) pdsh/pdcp default to local username
+- If you run as `alice`, pdsh will try `alice@<host>` unless told otherwise.
+- Force remote login name: `pdsh -l bob -w host1 'whoami; echo "$HOME"'`
+
+## pdsh usage patterns
+- Single host: `pdsh -l user -w host1 'hostname -f && uptime'`
+- Many hosts from a local file: `pdsh -l user -w ^"$HOME/.config/pdsh/hosts" 'uptime'`
+- Exclude a host (useful if the hostfile includes localhost but you don't want it):
+  `pdsh -l user -w ^"$HOME/.config/pdsh/hosts" -x localhost 'uptime'`
+
+## pdcp usage patterns (gotchas + fixes)
+### Gotcha A: `pdcp ... :~/.config/...`
+- Do **not** prefix remote paths with `:` here; pdcp already knows the remote via `-w`. Use a normal remote path.
+
+### Gotcha B: `~` expands locally
+- If you write: `pdcp -l user -w host1 ~/.config/pdsh/hosts ~/.config/pdsh/hosts`, your local shell expands `~` before pdcp runs -- this can accidentally turn the *remote* destination into your own local home path and fail.
+- Fix (safe):
+  - Create the remote dir first: `pdsh -l user -w host1 'mkdir -p ~/.config/pdsh && chmod 700 ~/.config/pdsh'`
+  - Copy using a relative dest (lands under remote `$HOME`): `pdcp -l user -w host1 "$HOME/.config/pdsh/hosts" ".config/pdsh/hosts"`
+  - Or keep `~` but prevent local expansion by quoting the dest: `pdcp -l user -w host1 "$HOME/.config/pdsh/hosts" '~/.config/pdsh/hosts'`
+
+### Gotcha C: `-L`
+- `pdcp -L` lists modules/info and exits (not a copy). Do not use it for copying.
+
+## Recommended minimal env on the fanout box
+`~/.config/pdsh/env.sh`:
+```sh
+export PDSH_RCMD_TYPE=ssh
+export PDSH_SSH_ARGS_APPEND="-oBatchMode=yes -oConnectTimeout=8 -oServerAliveInterval=30 -oServerAliveCountMax=2 -oStrictHostKeyChecking=accept-new"
+export WCOLL="$HOME/.config/pdsh/hosts"
+```
+
+## Quick verify checklist
+- SSH key auth (no prompts): `ssh -o BatchMode=yes user@host1 'echo OK'`
+- pdsh fanout: `pdsh -l user -w ^"$HOME/.config/pdsh/hosts" -x localhost 'hostname -f && uptime'`
+- pdcp file present: `pdsh -l user -w host1 'ls -l ~/.config/pdsh/hosts && head -n 5 ~/.config/pdsh/hosts'`
+
+## Lessons / guardrails
+- Always watch for `~` expansion when the destination is remote.
+- Keep "mixed-user" hostfiles separate (or use `-l` + `-x` to avoid localhost/user mismatch).
+- If SSH behaves inconsistently, compare `ssh -G` output across host tokens.
+
+## Delta: final checks / gotchas
+
+### SSH auth hygiene
+- Confirm a key is actually offered (useful when agent/config is weird):
+  `ssh -v host1 |& egrep -i 'Offering public key|Authentications that can continue'`
+- Enforce "no prompts allowed" across a fleet: `pdsh -l user -w ^~/.config/pdsh/hosts -x localhost 'true'`
+
+### Hostfile semantics
+- Mixed `user@host` entries + `-l someuser` can surprise you.
+  - Preferred: one hostfile per login (e.g. `hosts.alice`, `hosts.bob`)
+  - Or: always use `user@host` in WCOLL and avoid `-l`.
+
+### known_hosts / fingerprint drift
+- If boxes are rebuilt, be ready for "host key changed": `ssh-keygen -R <ip>` / `ssh-keygen -R <hostname>`
+
+### pdcp expectations
+- `pdcp` behaves best when remote has pdsh installed too.
+- Remember the `~` expansion footgun: don't use an unquoted `~` for a remote dest.
+
+### Network + sshd basics
+- On targets, confirm sshd is listening: `pdsh -l user -w ^~/.config/pdsh/hosts -x localhost 'ss -lntp | grep -E ":(22) " || true'`
+
+### Optional QoL
+- Speed up fanout with SSH multiplexing: add `-o ControlMaster=auto -o ControlPersist=5m` to the ssh args.
+- Cap concurrency if you go wide: `pdsh -f 16 ...` (tune as needed)

--- a/hee/cards/regns.seed.card.v1.yaml
+++ b/hee/cards/regns.seed.card.v1.yaml
@@ -1,0 +1,45 @@
+apiVersion: hee/v1
+kind: Card
+metadata:
+  name: regns-seed
+  description: "Seed proposal for kind: RegNs -- see hee.kind-registry.contract.v1.yaml's observed_kinds for status. Recovered from a private working repo 2026-08-24 and genericized (no private examples retained) for public consumption -- see fleet-ops#272 for the recovery epic."
+  labels:
+    hee.object: "true"
+    hee.state: candidate
+    domain: hee
+    scope: governance
+    topic: regns
+    artifact: card
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    created_utc: "2026-02-13T00:00:00-06:00"
+    recovered_utc: "2026-08-24T00:00:00Z"
+spec:
+  summary: >-
+    A first-class registry namespace for known-good regex and other reusable
+    string atoms (quotes, lyrics, now-playing snippets, etc). Goal: make
+    scattered regex + string fragments queryable, reusable, and attestable
+    across consumers (DNS tooling, log parsers, Prometheus rules, etc)
+    instead of re-derived ad hoc per-script.
+  principles:
+    - "Regex is first-class, not an incidental string literal buried in a script."
+    - "Prefer a small number of tiny, reusable tools over one-off tooling per use case."
+    - "Known-good patterns must be addressable by stable keys and purpose tags, not re-typed from memory."
+  model_ideas:
+    kind_name_candidates: ["RegNs", "RegNS", "RegexNS", "KindRegNs"]
+    record_types:
+      regex:
+        required_fields: ["key", "purpose", "pattern", "engine", "tests"]
+        purpose_examples: ["dns", "prom", "logs", "triage", "parsing"]
+      quote:
+        required_fields: ["key", "quote", "context", "source"]
+      lyric:
+        required_fields: ["key", "lyric", "artist", "track", "year", "source_hash"]
+      now_playing:
+        required_fields: ["value", "ts"]
+  needs_dif: true
+  dif:
+    - "confirm the kind name (RegNs vs alternatives above) before it graduates past observed_kinds"
+    - "find or create a first real consumer object -- promotion needs real usage, not a second proposal"
+    - "decide whether tests: on a regex record is a literal test-case list or a pointer to a real test file"

--- a/hee/contracts/hee.kind-registry.contract.v1.yaml
+++ b/hee/contracts/hee.kind-registry.contract.v1.yaml
@@ -28,6 +28,7 @@ spec:
 
   observed_kinds:
     Skill: "proposed 2026-08-14 -- a reusable, invokable PROCEDURE (narrower/more operational than a Blueprint, which is doctrine/principle-level). First real usage: hee/skills/ratify-contract-v1.skill.yaml, capturing the contract-ratification workflow that emerged from actually fixing a real sign-then-mutate ordering bug the same night. Pending promotion to active_kinds once reviewed -- same bar as Registry's promotion below, not skipped."
+    RegNs: "proposed 2026-02-13, recovered from a private working repo (tcos-plan-private) and brought into this registry 2026-08-24 -- a first-class registry namespace for known-good regex and other reusable string atoms (quote/lyric/now-playing/etc.), keyed by purpose tag so scattered patterns become queryable and attestable instead of re-derived per-script. No real HEE-side usage yet (only the one seed proposal it originated from) -- needs at least one real consumer before promotion to active_kinds, same bar as Skill above."
 
   promotion_note_2026_08_13: "Registry promoted from observed to active: hee/registries/dir-groups.registry.v1.yaml already used kind=Registry in production before this registry recognized it -- a pre-existing gap, not a new proposal. This file itself also failed its own envelope schema (missing required metadata.labels.hee.object) until this same edit; fixed together rather than left inconsistent while depending on it."
 

--- a/hee/pills/tmux-ui.render-stack.highlight.pill.v1.yaml
+++ b/hee/pills/tmux-ui.render-stack.highlight.pill.v1.yaml
@@ -1,0 +1,43 @@
+apiVersion: hee/v1
+kind: Pill
+metadata:
+  name: tmux-ui-render-stack-highlight
+  description: "Highlight: glow+bat+jq+yq as the TTY render stack. Recovered from a private working repo (tcos-plan-private) 2026-08-24 as part of the fleet-ops#272 recovery epic -- this is HEE's own design thinking, not TCOS-private business content, so the migration is a straight move. tooling/bin/hee-print (recovered in the same batch) is the real implementation of this pill's render-policy block below."
+  labels:
+    hee.object: "true"
+    domain: hee
+    scope: ui
+    topic: tmux-ui
+    artifact: highlight
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    created_utc: "2026-02-13T00:00:00-06:00"
+    recovered_utc: "2026-08-24T00:00:00Z"
+
+spec:
+  highlight:
+    claim: "The TTY render stack (glow + bat + jq + yq) makes a tmux-based UI feel inevitable; the feature mostly writes itself."
+    why_it_works:
+      - "Markdown becomes a native UI surface (glow)."
+      - "Raw text becomes readable without ceremony (bat/batcat)."
+      - "JSON/YAML become first-class inspection outputs (jq/yq)."
+      - "Pairs well with simple cat+EOF ingestion and script-driven execution."
+    implications:
+      - "A tmux UI should autodetect file types and render consistently."
+      - "HEE objects/pills remain human-friendly while still machine-parseable."
+      - "UI can be assembled from existing primitives instead of a bespoke frontend."
+
+  tmux_ui_contract_seed:
+    render_policy:
+      - match: "*.md"
+        cmd: "glow -p"
+      - match: "*.yaml"
+        cmd: "yq -P"
+      - match: "*.yml"
+        cmd: "yq -P"
+      - match: "*.json"
+        cmd: "jq ."
+      - match: "*"
+        cmd: "bat -p --paging=never"
+    real_implementation: "tooling/bin/hee-print -- recovered in the same batch, implements exactly this render_policy."

--- a/library/sh/hee-evidence-rg.sh
+++ b/library/sh/hee-evidence-rg.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# hee-evidence-rg.sh — ripgrep inside the repo evidence corpus (read-only helper)
+#
+# usage:
+#   hee-evidence-rg.sh <repo_root> <pattern> [rg args...]
+#
+# examples:
+#   ./library/sh/hee-evidence-rg.sh . "home occupation"
+#   ./library/sh/hee-evidence-rg.sh . "minneapolis" -i
+
+repo=${1:-}
+pat=${2:-}
+
+if [ -z "$repo" ] || [ -z "$pat" ]; then
+  echo "usage: $(basename "$0") <repo_root> <pattern> [rg args...]" >&2
+  exit 2
+fi
+shift 2
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "error: rg (ripgrep) not found on PATH" >&2
+  exit 127
+fi
+
+# evidence root auto-detect
+ev=""
+if [ -d "$repo/hee/evidence/src" ]; then
+  ev="$repo/hee/evidence/src"
+elif [ -d "$repo/hee/evidence" ]; then
+  ev="$repo/hee/evidence"
+else
+  echo "error: evidence root not found under $repo/hee/evidence/src or $repo/hee/evidence" >&2
+  exit 2
+fi
+
+# NOTE:
+# - exclude any nested .git dirs (Codex P2)
+# - use -e for pattern so leading '-' can't be parsed as flags (Codex P2)
+# - "$@" are extra rg args (now correctly positioned before pattern)
+rg --color=never -n --no-heading --hidden \
+  --glob '!**/.git/**' \
+  --glob '!**/node_modules/**' \
+  "$@" \
+  -e "$pat" \
+  "$ev"
+rc=$?
+
+case "$rc" in
+  0) exit 0 ;;
+  1) echo "no matches: $pat" >&2; exit 0 ;;
+  *) exit "$rc" ;;
+esac

--- a/tooling/bin/hee-print
+++ b/tooling/bin/hee-print
@@ -1,0 +1,105 @@
+#!/bin/sh
+# hee-print: render files nicely for terminal surfaces (tmux-ui, shellboss, humans)
+# POSIX sh, no prompts.
+
+usage() {
+  cat <<'USAGE'
+usage:
+  hee-print [--no-header] [--] <file>...
+  hee-print [--no-header] --stdin [--hint md|yaml|json|text]
+
+behavior:
+  .md/.markdown -> glow -p (if available)
+  .yml/.yaml    -> yq -P   (if available)
+  .json         -> jq .    (if available)
+  other         -> bat/batcat -p --paging=never (if available) else cat
+USAGE
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+pick_bat() {
+  if have bat; then echo bat; return; fi
+  if have batcat; then echo batcat; return; fi
+  echo ""
+}
+
+render_md() {
+  if have glow; then glow -p "$1"; else cat "$1"; fi
+}
+
+render_yaml() {
+  if have yq; then yq -P "$1"; else cat "$1"; fi
+}
+
+render_json() {
+  if have jq; then jq . < "$1"; else cat "$1"; fi
+}
+
+render_other() {
+  B="$(pick_bat)"
+  if [ -n "$B" ]; then
+    "$B" -p --paging=never "$1"
+  else
+    cat "$1"
+  fi
+}
+
+render_by_ext() {
+  f="$1"
+  case "$f" in
+    *.md|*.markdown) render_md "$f" ;;
+    *.yml|*.yaml)    render_yaml "$f" ;;
+    *.json)          render_json "$f" ;;
+    *)               render_other "$f" ;;
+  esac
+}
+
+no_header=0
+stdin_mode=0
+hint=""
+
+# arg parse
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-header) no_header=1; shift ;;
+    --stdin) stdin_mode=1; shift ;;
+    --hint) hint="${2:-}"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    --) shift; break ;;
+    -*) echo "unknown flag: $1" >&2; usage; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [ "$stdin_mode" -eq 1 ]; then
+  tmp="${TMPDIR:-/tmp}/hee-print.$$"
+  cat > "$tmp"
+  # best-effort hint routing
+  case "$hint" in
+    md)   render_md "$tmp" ;;
+    yaml) render_yaml "$tmp" ;;
+    json) render_json "$tmp" ;;
+    *)    render_other "$tmp" ;;
+  esac
+  rm -f "$tmp"
+  exit 0
+fi
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 2
+fi
+
+for f in "$@"; do
+  if [ ! -f "$f" ]; then
+    echo "missing file: $f" >&2
+    continue
+  fi
+  if [ "$no_header" -eq 0 ] && [ $# -gt 1 ]; then
+    echo ""
+    echo "### $f"
+    echo ""
+  fi
+  render_by_ext "$f"
+done

--- a/tooling/bin/hee-tools
+++ b/tooling/bin/hee-tools
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+sub="${1:-check}"
+case "$sub" in
+  check|"")
+    shift || true
+    exec "$(dirname "$0")/hee-tools-check" "$@"
+    ;;
+  update)
+    shift
+    exec "$(dirname "$0")/hee-tools-update" "$@"
+    ;;
+  *)
+    echo "usage: hee tools [check|update]" >&2
+    exit 2
+    ;;
+esac

--- a/tooling/bin/hee-tools-check
+++ b/tooling/bin/hee-tools-check
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+# Resolve manifest relative to this script, so it works from any CWD.
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+DEFAULT_MANIFEST="$SCRIPT_DIR/../tools.manifest.txt"
+MANIFEST="${1:-$DEFAULT_MANIFEST}"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+vline() {
+  n="$1"
+  if have "$n"; then
+    if "$n" --version >/dev/null 2>&1; then
+      ver=$("$n" --version | head -n 1)
+    elif "$n" -V >/dev/null 2>&1; then
+      ver=$("$n" -V | head -n 1)
+    else
+      ver="(version-flag-unknown)"
+    fi
+    printf "🟢 + %-8s %s\n" "$n" "$ver"
+  else
+    printf "🔴 - %-8s missing\n" "$n"
+  fi
+}
+
+echo "### hee-tools-check"
+echo "manifest: $MANIFEST"
+echo ""
+
+# name kind desired (ignore kind/desired for now; check presence+version string)
+while IFS= read -r line; do
+  case "$line" in
+    ""|\#*) continue ;;
+  esac
+  set -- $line
+  name="$1"
+  vline "$name"
+done < "$MANIFEST"

--- a/tooling/bin/hee-tools-update
+++ b/tooling/bin/hee-tools-update
@@ -1,0 +1,103 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+DEFAULT_MANIFEST="$SCRIPT_DIR/../tools.manifest.txt"
+MANIFEST="${1:-$DEFAULT_MANIFEST}"
+EVD_DIR="${2:-hee/evidence/tools}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$EVD_DIR/tools-update.$TS.log"
+
+mkdir -p "$EVD_DIR" "$HOME/.local/bin" "$HOME/.local/go"
+
+log() { printf "%s\n" "$*" | tee -a "$OUT" >/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+install_go_tar() {
+  gov="$1"
+  arch="amd64"
+  os="linux"
+  t="go${gov}.${os}-${arch}.tar.gz"
+  url="https://go.dev/dl/${t}"
+  tmp="${TMPDIR:-/tmp}/${t}"
+  dest="$HOME/.local/go/${gov}"
+
+  log "== go install ${gov} =="
+  log "curl $url"
+  curl -fsSL -o "$tmp" "$url"
+  log "sha256:"
+  sha256sum "$tmp" | tee -a "$OUT" >/dev/null
+
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  tar -C "$dest" -xzf "$tmp"
+
+  ln -sf "$dest/go/bin/go" "$HOME/.local/bin/go"
+  ln -sf "$dest/go/bin/gofmt" "$HOME/.local/bin/gofmt"
+
+  if have go; then
+    log "go version: $(go version)"
+  else
+    log "🔴 go not on PATH; add ~/.local/bin to PATH"
+  fi
+}
+
+install_yq_bin() {
+  yqv="$1"
+  arch="amd64"
+  os="linux"
+  url="https://github.com/mikefarah/yq/releases/download/v${yqv}/yq_${os}_${arch}"
+  out="$HOME/.local/bin/yq"
+
+  log "== yq install v${yqv} =="
+  log "curl $url -> $out"
+  curl -fsSL -o "$out" "$url"
+  chmod +x "$out"
+  log "yq version: $(yq --version || true)"
+}
+
+log "### hee-tools-update"
+log "manifest: $MANIFEST"
+log "out: $OUT"
+log ""
+
+while IFS= read -r line; do
+  case "$line" in
+    ""|\#*) continue ;;
+  esac
+  set -- $line
+  name="$1"; kind="$2"; desired="$3"
+
+  case "$name:$kind" in
+    go:tar)
+      install_go_tar "$desired"
+      ;;
+    yq:bin)
+      if have yq; then
+        cur="$(yq --version | sed -n 's/.*version v\{0,1\}\([0-9.]\+\).*/\1/p' | head -n 1)"
+        log "yq current: ${cur:-unknown} desired: $desired"
+        if [ "${cur:-}" != "$desired" ]; then
+          install_yq_bin "$desired"
+        else
+          log "yq ok"
+        fi
+      else
+        install_yq_bin "$desired"
+      fi
+      ;;
+    jq:pkg|bat:pkg|glow:pkg|rg:pkg|tmux:pkg)
+      if have "$name"; then
+        log "== $name ok (present) =="
+      else
+        log "== $name missing =="
+        log "hint (debian/ubuntu): sudo apt install $name"
+      fi
+      ;;
+    *)
+      log "🟡 unknown manifest entry: $name $kind $desired"
+      ;;
+  esac
+done < "$MANIFEST"
+
+log ""
+log "done"

--- a/tooling/tools.manifest.txt
+++ b/tooling/tools.manifest.txt
@@ -1,0 +1,8 @@
+# name  kind    desired
+go      tar     1.26.0
+yq      bin     4.50.1
+jq      pkg     any
+bat     pkg     any
+glow    pkg     any
+rg      pkg     any
+tmux    pkg     any


### PR DESCRIPTION
Part of [fleet-ops#272](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/272). Sanitize-and-generalize pass: real doctrine pulled out of a private working repo and made public-safe, while the org-specific instances stay private and unchanged -- same public-schema/private-data split already established by `inventory.contract.v1.md`.

- `regns.seed.card.v1.yaml` + kind-registry entry: real orphaned Kind proposal, genericized.
- `tcos.mna.hee-sale-deal.contract.v1.yaml`: real M&A valuation contract, promoted as-is (already had no private specifics).
- `treasury-invariants-v1.contract.yaml`: genericized from a real private treasury DIF -- no dollar figures/entity names carried over.
- `kinship-membership-governance-v1.yaml`: genericized from a real private family-governance DIF -- no real names carried over.
- `org-foundation-design-v1.yaml`: genericized from a real private foundation/newco DIF pair -- ceremony shape only, not any org's actual content.

Reviewed every source file directly before writing these; none of the new public files contain private identifiers, dollar figures, or personal names.