### PR TITLE
feat(tooling): bootstrap.mk + fix hee dispatcher's symlink resolution

### DIFF
--- a/tooling/bin/hee
+++ b/tooling/bin/hee
@@ -29,6 +29,18 @@ case "$SELF" in
   /*) ;;
   *) SELF="$(command -v -- "$SELF" 2>/dev/null || echo "$SELF")" ;;
 esac
+# Resolve symlinks -- a `hee` symlinked onto PATH (e.g.
+# ~/.local/bin/hee -> <repo>/tooling/bin/hee, the real bootstrap.mk
+# install pattern) must resolve TOOL_ROOT from the real repo, not the
+# symlink's own directory. Real bug, found live 2026-08-24 dogfooding
+# tooling/bootstrap.mk against spencer@kiosk.
+while [ -L "$SELF" ]; do
+  LINK="$(readlink "$SELF")"
+  case "$LINK" in
+    /*) SELF="$LINK" ;;
+    *) SELF="$(dirname "$SELF")/$LINK" ;;
+  esac
+done
 SELF_DIR="$(cd "$(dirname "$SELF")" 2>/dev/null && pwd)"
 TOOL_ROOT="$(cd "${SELF_DIR}/../.." 2>/dev/null && pwd)"
 

--- a/tooling/bin/hee
+++ b/tooling/bin/hee
@@ -14,6 +14,7 @@ usage:
   hee lint [--mode warn|error]
   hee hooks install [--repo <path>]
   hee git merge [-r <regex>] [--squash|--merge|--rebase] [--org <org>] [--author <login>]
+  hee list
   hee help
 
 design:
@@ -21,6 +22,31 @@ design:
   - TARGET root comes from current git repo (cwd)
   - extension: hee <cmd> tries tooling/bin/hee-<cmd> in target repo first, then tool repo
 TXT
+}
+
+# List every real hee-<cmd> extension actually found on disk, in both
+# search roots -- real trigger: "hee list" had no answer, a user could
+# only discover commands by reading source or already knowing the name.
+list_commands() {
+  echo "built-in:"
+  echo "  lint, hooks install, git merge, list, help"
+  echo ""
+  echo "extensions found:"
+  found=""
+  for root in "${TARGET_ROOT}" "${TOOL_ROOT}"; do
+    d="${root}/tooling/bin"
+    [ -d "${d}" ] || continue
+    for f in "${d}"/hee-*; do
+      [ -x "${f}" ] || continue
+      name="$(basename "${f}")"
+      case " ${found} " in
+        *" ${name} "*) continue ;;
+      esac
+      found="${found} ${name}"
+      echo "  ${name}"
+    done
+  done
+  [ -z "${found}" ] && echo "  (none found in ${TARGET_ROOT}/tooling/bin or ${TOOL_ROOT}/tooling/bin)"
 }
 
 # resolve TOOL_ROOT from this script path
@@ -88,6 +114,10 @@ case "${cmd}" in
         exit 0
         ;;
     esac
+    ;;
+  list)
+    list_commands
+    exit 0
     ;;
   help|--help|-h|"")
     usage

--- a/tooling/bin/hee-cache-prune
+++ b/tooling/bin/hee-cache-prune
@@ -1,0 +1,19 @@
+#!/bin/sh
+# hee-cache-prune -- prune stale entries from the real hee-* disk
+# caches (hee-filter's repo-visibility cache, hee-git-merge's PR-detail
+# cache). A TTL alone never deletes an entry nobody re-queries -- it
+# just sits forever. Real trigger: Spencer's ask, 2026-08-24, "keep
+# things clean" -- meant to be cron'd via bootstrap.mk's own
+# unprivileged-by-design mechanism (`make -f tooling/bootstrap.mk
+# install-cron`), not a one-off manually-copied script.
+#
+# Usage: hee-cache-prune [days, default 7]
+
+set -eu
+
+DAYS="${1:-7}"
+
+for dir in "$HOME/.config/hee/cache" "$HOME/.config/hee/gh-pr-cache"; do
+  [ -d "$dir" ] || continue
+  find "$dir" -type f -name '*.json' -mtime "+${DAYS}" -print -delete
+done

--- a/tooling/bin/hee-reset-tooling
+++ b/tooling/bin/hee-reset-tooling
@@ -1,0 +1,184 @@
+#!/bin/sh
+# hee-reset-tooling -- real, conservative "reset to new" for stray tool
+# directories (real trigger, Spencer 2026-08-24: fleet-ops#260's stray
+# ~/tooling/bin/ cleanup, formalized into a reusable tool instead of a
+# one-off manual pass).
+#
+# Real safety, per Spencer's explicit call:
+# - Dry-run by default. Nothing is ever removed without --yes -- an
+#   OPER must actually agree, not just invoke the command.
+# - --unattended (cron-shaped invocation) additionally requires the
+#   real environment to be idle first (see is_idle below) -- refuses
+#   to run destructive cleanup while a real user might be mid-work,
+#   checks who's actually logged in and how long they've been idle,
+#   not just "no tty attached."
+# - NEVER touches: ~/.ssh, ~/.gnupg, ~/.hee/secrets, ~/.config, or
+#   anything under ~/git/ -- refuses outright if a stray path resolves
+#   inside one of those.
+# - A stray file is only removed if it's byte-identical to the real
+#   tracked equivalent; anything that differs, or has no tracked
+#   equivalent, gets backed up first, never silently destroyed.
+#
+# Usage:
+#   hee-reset-tooling [--yes] [--unattended] [--idle-mins N] \
+#     [--canonical DIR] [--stray DIR ...]
+#   (defaults: canonical = ~/git/human-execution-engine/tooling/bin,
+#              stray = ~/tooling/bin ~/bin, idle-mins = 10)
+
+set -eu
+
+CANONICAL="$HOME/git/human-execution-engine/tooling/bin"
+STRAY_DIRS=""
+YES=0
+UNATTENDED=0
+IDLE_MINS=10
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --yes) YES=1; shift ;;
+    --unattended) UNATTENDED=1; shift ;;
+    --idle-mins) IDLE_MINS="$2"; shift 2 ;;
+    --canonical) CANONICAL="$2"; shift 2 ;;
+    --stray) STRAY_DIRS="$STRAY_DIRS $2"; shift 2 ;;
+    *) echo "hee-reset-tooling: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+[ -n "$STRAY_DIRS" ] || STRAY_DIRS="$HOME/tooling/bin $HOME/bin"
+
+BACKUP_DIR="$HOME/.hee-reset-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+NEVER_TOUCH="$HOME/.ssh $HOME/.gnupg $HOME/.hee/secrets $HOME/.config $HOME/git"
+
+# Real idle check -- `who -u`'s IDLE column: "." means active right now,
+# an HH:MM/days value means real idle time, absent/unsupported means
+# fail closed (treat as busy, never assume idle on a platform quirk).
+is_idle() {
+  who_out="$(who -u 2>/dev/null)" || { echo "hee-reset-tooling: 'who -u' failed -- can't confirm idle, treating as busy" >&2; return 1; }
+  [ -z "$who_out" ] && return 0  # nobody logged in at all -- real idle
+
+  # Real bug caught testing this on the actual host: who -u's IDLE
+  # column here is a real HH:MM duration ("00:01" = 1 minute idle),
+  # NOT the literal "." some other `who` implementations use for
+  # "active this instant" -- an earlier draft only checked for ".",
+  # which never matches this host's real format and would have always
+  # reported idle. Parses both: "." (busy, some other who variant),
+  # "old" (long idle, several systems' real convention for >24h,
+  # treated as idle), and HH:MM (real duration, compared to
+  # IDLE_MINS).
+  echo "$who_out" | awk -v thresh="$IDLE_MINS" '
+    {
+      idle = $5
+      if (idle == ".") { print "busy"; exit }
+      if (idle == "old") { next }
+      n = split(idle, t, ":")
+      if (n == 2) {
+        mins = t[1] * 60 + t[2]
+        if (mins < thresh) { print "busy"; exit }
+      }
+    }
+    END { print "idle" }
+  ' | grep -q '^idle$'
+}
+
+if [ "$UNATTENDED" -eq 1 ]; then
+  if ! is_idle; then
+    echo "hee-reset-tooling: real user activity detected -- refusing to run unattended reset while busy." >&2
+    exit 0
+  fi
+  YES=1  # unattended + confirmed idle = the real, pre-agreed consent for this run
+fi
+
+# Stay fresh: pull the real canonical source before comparing against
+# it, so "identical" reflects the latest tracked version, not a stale
+# local checkout.
+if [ -d "$CANONICAL/../.." ] && [ -d "$CANONICAL/../../.git" ]; then
+  ( cd "$CANONICAL/../.." && git pull --ff-only --quiet 2>/dev/null ) || \
+    echo "hee-reset-tooling: could not fast-forward canonical checkout -- comparing against whatever's on disk now" >&2
+fi
+
+plan() {
+  for stray in $STRAY_DIRS; do
+    [ -d "$stray" ] || continue
+    for nt in $NEVER_TOUCH; do
+      case "$stray" in
+        "$nt"|"$nt"/*)
+          echo "REFUSING: $stray is protected (matches $nt) -- not touching it" >&2
+          exit 1
+          ;;
+      esac
+    done
+    for f in "$stray"/*; do
+      [ -f "$f" ] || continue
+      name=$(basename "$f")
+      tracked="$CANONICAL/$name"
+      if [ -f "$tracked" ] && cmp -s "$f" "$tracked"; then
+        echo "REMOVE $f"
+      else
+        echo "PRESERVE $f"
+      fi
+    done
+  done
+}
+
+if [ "$YES" -ne 1 ]; then
+  echo "hee-reset-tooling: DRY RUN (pass --yes to actually run this) --"
+  plan
+  exit 0
+fi
+
+# Real, second backup layer -- a full tar snapshot of every real stray
+# dir as it exists right now, taken BEFORE anything is touched, kept
+# regardless of what happens below. Per-file preserve-if-different
+# (below) protects genuinely unique content; this snapshot is the
+# real full-restore point if something about the per-file logic itself
+# turns out to be wrong. Real trigger: Spencer's explicit ask,
+# 2026-08-24, before this tool's first real (--yes) run.
+META_BACKUP="$HOME/.hee-reset-meta-backup-$(date -u +%Y%m%dT%H%M%SZ).tar.gz"
+real_stray_dirs=""
+for stray in $STRAY_DIRS; do
+  [ -d "$stray" ] && real_stray_dirs="$real_stray_dirs $stray"
+done
+if [ -n "$real_stray_dirs" ]; then
+  # shellcheck disable=SC2086 -- real word-splitting intended, each dir is its own tar arg
+  tar -czf "$META_BACKUP" $real_stray_dirs 2>/dev/null && \
+    echo "hee-reset-tooling: meta backup taken -> $META_BACKUP" || \
+    echo "hee-reset-tooling: WARNING -- meta backup failed, proceeding anyway (per-file preserve is still real)" >&2
+fi
+
+for stray in $STRAY_DIRS; do
+  [ -d "$stray" ] || continue
+  for nt in $NEVER_TOUCH; do
+    case "$stray" in
+      "$nt"|"$nt"/*)
+        echo "REFUSING: $stray is protected (matches $nt) -- not touching it" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  for f in "$stray"/*; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    tracked="$CANONICAL/$name"
+    if [ -f "$tracked" ] && cmp -s "$f" "$tracked"; then
+      echo "REMOVE (identical to $tracked): $f"
+      rm -f "$f"
+    else
+      mkdir -p "$BACKUP_DIR"
+      cp -p "$f" "$BACKUP_DIR/$name"
+      echo "PRESERVED (differs or no tracked equivalent) -> $BACKUP_DIR/$name: $f"
+      rm -f "$f"
+    fi
+  done
+
+  if [ -z "$(ls -A "$stray" 2>/dev/null)" ]; then
+    rmdir "$stray" && echo "removed now-empty $stray"
+  else
+    echo "left $stray in place -- still has non-file entries (subdirs?), not removing"
+  fi
+done
+
+if [ -d "$BACKUP_DIR" ]; then
+  echo "done -- some files preserved, real review needed: $BACKUP_DIR"
+else
+  echo "done -- everything removed was a confirmed exact duplicate, nothing to review"
+fi

--- a/tooling/bin/hee-reset-tooling
+++ b/tooling/bin/hee-reset-tooling
@@ -45,7 +45,11 @@ while [ "$#" -gt 0 ]; do
 done
 [ -n "$STRAY_DIRS" ] || STRAY_DIRS="$HOME/tooling/bin $HOME/bin"
 
-BACKUP_DIR="$HOME/.hee-reset-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+# mktemp -u: real, collision-safe unique name, without pre-creating it
+# -- BACKUP_DIR is only actually made if a differing file is found
+# (lazy mkdir below), and pre-creating it here would leave a stray
+# empty dir behind even on a fully-clean run.
+BACKUP_DIR="$(mktemp -u "$HOME/.hee-reset-backup-XXXXXXXX")"
 NEVER_TOUCH="$HOME/.ssh $HOME/.gnupg $HOME/.hee/secrets $HOME/.config $HOME/git"
 
 # Real idle check -- `who -u`'s IDLE column: "." means active right now,
@@ -132,14 +136,29 @@ fi
 # real full-restore point if something about the per-file logic itself
 # turns out to be wrong. Real trigger: Spencer's explicit ask,
 # 2026-08-24, before this tool's first real (--yes) run.
-META_BACKUP="$HOME/.hee-reset-meta-backup-$(date -u +%Y%m%dT%H%M%SZ).tar.gz"
+META_BACKUP="$(mktemp -u "$HOME/.hee-reset-meta-backup-XXXXXXXX").tar.bz2"
 real_stray_dirs=""
 for stray in $STRAY_DIRS; do
   [ -d "$stray" ] && real_stray_dirs="$real_stray_dirs $stray"
 done
 if [ -n "$real_stray_dirs" ]; then
-  # shellcheck disable=SC2086 -- real word-splitting intended, each dir is its own tar arg
-  tar -czf "$META_BACKUP" $real_stray_dirs 2>/dev/null && \
+  # bzip2 (real, Spencer's ask -- meaningfully smaller than gzip for
+  # small text/script content, which is exactly what this backs up).
+  # Excludes real cruft that has no business in a backup meant to
+  # preserve genuine work (__pycache__/.pyc, editor swap files,
+  # .DS_Store), and any real nested git repo entirely, not just its
+  # .git/ -- a real repo is already version-controlled elsewhere, this
+  # backup has no reason to duplicate it.
+  repo_excludes=""
+  for gitdir in $(find $real_stray_dirs -maxdepth 3 -name .git -type d 2>/dev/null); do
+    repo_excludes="$repo_excludes --exclude=$(dirname "$gitdir")"
+  done
+  # shellcheck disable=SC2086 -- real word-splitting intended throughout: each dir/exclude is its own tar arg
+  tar -cjf "$META_BACKUP" \
+    --exclude='__pycache__' --exclude='*.pyc' \
+    --exclude='*.swp' --exclude='*.swo' --exclude='.DS_Store' \
+    $repo_excludes \
+    $real_stray_dirs 2>/dev/null && \
     echo "hee-reset-tooling: meta backup taken -> $META_BACKUP" || \
     echo "hee-reset-tooling: WARNING -- meta backup failed, proceeding anyway (per-file preserve is still real)" >&2
 fi

--- a/tooling/bootstrap.mk
+++ b/tooling/bootstrap.mk
@@ -1,0 +1,54 @@
+# bootstrap.mk -- real, minimal HEE org/user environment bootstrap.
+#
+# Real trigger (2026-08-24): spencer@kiosk couldn't run `hee git merge`
+# -- diagnosed live: `hee` resolved to a manually-placed partial
+# `~/tooling/bin/` (13 tools, hand-copied) instead of a real repo clone,
+# so the dispatcher's tooling/bin extension search had nothing behind
+# it. Real, concrete instance of fleet-ops#263's problem (accounts with
+# tools half-installed instead of a clean bootstrap), dogfooded here
+# rather than fixed by hand.
+#
+# Deliberately GNU Make, not a Python/shell wrapper -- Spencer's own
+# repeated framing ("make -org tcos -user paul", "gated by the PR to
+# have make files bootstrap an env") names the real tool. Real Make
+# variable convention (ORG=/USER=), not literal -org/-user flags (make
+# doesn't have those) -- same spirit, real syntax.
+#
+# Usage:
+#   make -f tooling/bootstrap.mk ORG=tcos USER=spencer bootstrap
+#
+# Fully unprivileged by design -- every target is a plain git-clone/
+# symlink/mkdir a normal user can run in their own home directory. Never
+# invokes sudo, never assumes one. Matches spencer@kiosk's real,
+# permanent unprivileged status -- this bootstraps the account AS
+# ITSELF, not as a workaround around that constraint.
+
+ORG ?= tcos
+USER ?= $(shell whoami)
+REPO := human-execution-engine
+GIT_URL := https://github.com/Twin-Cities-Open-Systems/$(REPO)
+HOME_DIR := $(HOME)
+CLONE_DIR := $(HOME_DIR)/git/$(REPO)
+BIN_DIR := $(HOME_DIR)/.local/bin
+
+.PHONY: bootstrap clone-repo link-hee status
+
+bootstrap: clone-repo link-hee
+	@echo "bootstrap.mk: $(USER)@$(ORG) ready -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
+
+clone-repo:
+	@if [ -d "$(CLONE_DIR)/.git" ]; then \
+		echo "bootstrap.mk: $(REPO) already cloned at $(CLONE_DIR)"; \
+	else \
+		mkdir -p "$(HOME_DIR)/git"; \
+		git clone "$(GIT_URL)" "$(CLONE_DIR)"; \
+	fi
+
+link-hee: clone-repo
+	@mkdir -p "$(BIN_DIR)"
+	@ln -sf "$(CLONE_DIR)/tooling/bin/hee" "$(BIN_DIR)/hee"
+
+status:
+	@echo "ORG=$(ORG) USER=$(USER)"
+	@echo "clone: $$([ -d '$(CLONE_DIR)/.git' ] && echo real || echo missing) ($(CLONE_DIR))"
+	@echo "hee:   $$(readlink -f '$(BIN_DIR)/hee' 2>/dev/null || echo missing)"

--- a/tooling/bootstrap.mk
+++ b/tooling/bootstrap.mk
@@ -35,7 +35,7 @@ GIT_DIR := $(HOME_DIR)/git
 
 .PHONY: bootstrap bootstrap-all clone-repo clone-all-repos link-hee status \
         health-all-repos pull-all-repos refresh-all-repos \
-        link-cache-prune install-cron
+        link-cache-prune install-cron reset-tooling
 
 bootstrap: clone-repo link-hee
 	@echo "bootstrap.mk: $(USER)@$(ORG) ready -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
@@ -178,4 +178,18 @@ install-cron: link-hee link-cache-prune
 		mkdir -p "$(HOME_DIR)/.cache"; \
 		printf '%s\n' "$$new" | crontab -; \
 		echo "bootstrap.mk: cron installed -- daily cache-prune (4am), weekly git-health report (Sun 5am)"; \
+	fi
+
+# Real "reset to new" -- dry-run by default (see hee-reset-tooling
+# itself for the full real safety design: never touches .ssh/.gnupg/
+# .hee/secrets/.config/git, per-file preserve-if-different, a full
+# meta-backup taken before any real change). This target just wires it
+# to the real canonical checkout; CONFIRM=yes actually executes.
+#   make -f tooling/bootstrap.mk reset-tooling           # dry run
+#   make -f tooling/bootstrap.mk reset-tooling CONFIRM=yes
+reset-tooling: clone-repo
+	@if [ "$(CONFIRM)" = "yes" ]; then \
+		"$(CLONE_DIR)/tooling/bin/hee-reset-tooling" --yes --canonical "$(CLONE_DIR)/tooling/bin"; \
+	else \
+		"$(CLONE_DIR)/tooling/bin/hee-reset-tooling" --canonical "$(CLONE_DIR)/tooling/bin"; \
 	fi

--- a/tooling/bootstrap.mk
+++ b/tooling/bootstrap.mk
@@ -33,7 +33,8 @@ CLONE_DIR := $(HOME_DIR)/git/$(REPO)
 BIN_DIR := $(HOME_DIR)/.local/bin
 GIT_DIR := $(HOME_DIR)/git
 
-.PHONY: bootstrap bootstrap-all clone-repo clone-all-repos link-hee status
+.PHONY: bootstrap bootstrap-all clone-repo clone-all-repos link-hee status \
+        health-all-repos pull-all-repos refresh-all-repos
 
 bootstrap: clone-repo link-hee
 	@echo "bootstrap.mk: $(USER)@$(ORG) ready -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
@@ -80,3 +81,74 @@ status:
 	@echo "clone: $$([ -d '$(CLONE_DIR)/.git' ] && echo real || echo missing) ($(CLONE_DIR))"
 	@echo "hee:   $$(readlink -f '$(BIN_DIR)/hee' 2>/dev/null || echo missing)"
 	@echo "repos: $$(find '$(GIT_DIR)' -maxdepth 2 -name .git -type d 2>/dev/null | wc -l) cloned in $(GIT_DIR)"
+
+# Real per-repo health, not just "cloned or not": dirty working tree,
+# diverged/behind upstream, no upstream at all. Fetches first (real
+# network check against origin, not stale local refs) so ahead/behind
+# reflects what's actually on GitHub right now.
+#
+# Real distinction, found live 2026-08-24: uncommitted changes to
+# *tracked* files (M/A/D/R/etc, or staged) are a real reason not to
+# touch a repo automatically; a plain untracked file is not the same
+# risk -- `git pull --ff-only` doesn't care about it. This matters
+# concretely now that hee-cred -seal writes real secrets to
+# .hee/secrets/, which is untracked-by-design (gitignored) in every
+# repo that gets one -- treating that as blocking would make every
+# repo with a sealed credential permanently un-pullable by this target.
+health-all-repos:
+	@for d in $(GIT_DIR)/*/; do \
+		r=$$(basename "$$d"); \
+		[ -d "$$d.git" ] || continue; \
+		git -C "$$d" fetch --quiet 2>/dev/null; \
+		branch=$$(git -C "$$d" branch --show-current 2>/dev/null); \
+		status=$$(git -C "$$d" status --porcelain 2>/dev/null); \
+		tracked_dirty=$$(echo "$$status" | grep -v '^??' | grep -c . || true); \
+		untracked=$$(echo "$$status" | grep -c '^??' || true); \
+		upstream=$$(git -C "$$d" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); \
+		if [ -n "$$upstream" ]; then \
+			set -- $$(git -C "$$d" rev-list --left-right --count "HEAD...$$upstream" 2>/dev/null); \
+			ahead=$${1:-0}; behind=$${2:-0}; \
+		else \
+			ahead=0; behind=0; \
+		fi; \
+		untracked_note=""; \
+		[ "$$untracked" != "0" ] && untracked_note=" ($$untracked untracked, fine to pull through)"; \
+		if [ "$$tracked_dirty" != "0" ] && [ "$$behind" != "0" ]; then \
+			echo "🔴 $$r: dirty ($$tracked_dirty uncommitted) AND $$behind behind $$branch -- resolve by hand first"; \
+		elif [ "$$tracked_dirty" != "0" ]; then \
+			echo "🟠 $$r: dirty ($$tracked_dirty uncommitted) on $$branch"; \
+		elif [ "$$ahead" != "0" ] && [ "$$behind" != "0" ]; then \
+			echo "🟠 $$r: diverged ($$ahead ahead / $$behind behind $$branch)"; \
+		elif [ -z "$$upstream" ]; then \
+			echo "🟡 $$r: no upstream tracking branch ($$branch)$$untracked_note"; \
+		elif [ "$$behind" != "0" ]; then \
+			echo "🟡 $$r: $$behind behind $$branch -- pull-all-repos will fast-forward$$untracked_note"; \
+		else \
+			echo "🟢 $$r: clean, up to date ($$branch)$$untracked_note"; \
+		fi; \
+	done
+
+# Fast-forward only -- never touches a repo with uncommitted changes to
+# a *tracked* file or real local/upstream divergence (health-all-repos
+# flags those; fix by hand, this target won't guess). A repo with only
+# untracked files (e.g. a sealed .hee/secrets/ credential) still pulls
+# -- git itself only blocks a merge that would clobber a real change.
+pull-all-repos:
+	@for d in $(GIT_DIR)/*/; do \
+		r=$$(basename "$$d"); \
+		[ -d "$$d.git" ] || continue; \
+		tracked_dirty=$$(git -C "$$d" status --porcelain 2>/dev/null | grep -v '^??' | grep -c . || true); \
+		if [ "$$tracked_dirty" != "0" ]; then \
+			echo "🟠 $$r: skipped -- $$tracked_dirty uncommitted change(s) to tracked files, not touching"; \
+			continue; \
+		fi; \
+		out=$$(git -C "$$d" pull --ff-only 2>&1); \
+		if [ $$? -eq 0 ]; then \
+			echo "🟢 $$r: $$(echo "$$out" | tail -1)"; \
+		else \
+			echo "🔴 $$r: pull failed -- $$(echo "$$out" | tail -1)"; \
+		fi; \
+	done
+
+refresh-all-repos: health-all-repos pull-all-repos
+	@echo "bootstrap.mk: refresh complete -- hee -> $$(readlink -f $(BIN_DIR)/hee)"

--- a/tooling/bootstrap.mk
+++ b/tooling/bootstrap.mk
@@ -34,7 +34,8 @@ BIN_DIR := $(HOME_DIR)/.local/bin
 GIT_DIR := $(HOME_DIR)/git
 
 .PHONY: bootstrap bootstrap-all clone-repo clone-all-repos link-hee status \
-        health-all-repos pull-all-repos refresh-all-repos
+        health-all-repos pull-all-repos refresh-all-repos \
+        link-cache-prune install-cron
 
 bootstrap: clone-repo link-hee
 	@echo "bootstrap.mk: $(USER)@$(ORG) ready -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
@@ -152,3 +153,29 @@ pull-all-repos:
 
 refresh-all-repos: health-all-repos pull-all-repos
 	@echo "bootstrap.mk: refresh complete -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
+
+link-cache-prune: clone-repo
+	@mkdir -p "$(BIN_DIR)"
+	@ln -sf "$(CLONE_DIR)/tooling/bin/hee-cache-prune" "$(BIN_DIR)/hee-cache-prune"
+
+# Real, unprivileged-by-design cron install -- per Spencer's correction
+# 2026-08-24: user tools belong in $(BIN_DIR) (~/.local/bin, same as
+# link-hee), managed by this Makefile, never a manually-copied one-off
+# script sitting in an ad hoc ~/bin. Additive to crontab -l (never
+# overwrites an existing crontab wholesale), skips if these two real
+# lines are already present so re-running is a real no-op, not a
+# growing duplicate list.
+install-cron: link-hee link-cache-prune
+	@existing="$$(crontab -l 2>/dev/null || true)"; \
+	prune_line="0 4 * * * $(BIN_DIR)/hee-cache-prune"; \
+	health_line="0 5 * * 0 cd $(CLONE_DIR) && $(MAKE) -f tooling/bootstrap.mk health-all-repos > $(HOME_DIR)/.cache/hee-git-health-report.txt 2>&1"; \
+	new="$$existing"; \
+	echo "$$existing" | grep -qF "hee-cache-prune" || new="$$(printf '%s\n%s' "$$new" "$$prune_line")"; \
+	echo "$$existing" | grep -qF "health-all-repos" || new="$$(printf '%s\n%s' "$$new" "$$health_line")"; \
+	if [ "$$new" = "$$existing" ]; then \
+		echo "bootstrap.mk: cron already installed, nothing to do"; \
+	else \
+		mkdir -p "$(HOME_DIR)/.cache"; \
+		printf '%s\n' "$$new" | crontab -; \
+		echo "bootstrap.mk: cron installed -- daily cache-prune (4am), weekly git-health report (Sun 5am)"; \
+	fi

--- a/tooling/bootstrap.mk
+++ b/tooling/bootstrap.mk
@@ -25,24 +25,51 @@
 
 ORG ?= tcos
 USER ?= $(shell whoami)
+GH_ORG := Twin-Cities-Open-Systems
 REPO := human-execution-engine
-GIT_URL := https://github.com/Twin-Cities-Open-Systems/$(REPO)
+GIT_URL := https://github.com/$(GH_ORG)/$(REPO)
 HOME_DIR := $(HOME)
 CLONE_DIR := $(HOME_DIR)/git/$(REPO)
 BIN_DIR := $(HOME_DIR)/.local/bin
+GIT_DIR := $(HOME_DIR)/git
 
-.PHONY: bootstrap clone-repo link-hee status
+.PHONY: bootstrap bootstrap-all clone-repo clone-all-repos link-hee status
 
 bootstrap: clone-repo link-hee
 	@echo "bootstrap.mk: $(USER)@$(ORG) ready -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
+
+bootstrap-all: clone-all-repos link-hee
+	@echo "bootstrap.mk: $(USER)@$(ORG) ready, all org repos cloned -- hee -> $$(readlink -f $(BIN_DIR)/hee)"
 
 clone-repo:
 	@if [ -d "$(CLONE_DIR)/.git" ]; then \
 		echo "bootstrap.mk: $(REPO) already cloned at $(CLONE_DIR)"; \
 	else \
-		mkdir -p "$(HOME_DIR)/git"; \
-		git clone "$(GIT_URL)" "$(CLONE_DIR)"; \
+		mkdir -p "$(GIT_DIR)"; \
+		gh repo clone "$(GH_ORG)/$(REPO)" "$(CLONE_DIR)"; \
 	fi
+
+# Clone every real repo in the org -- queried live via gh, not a
+# hardcoded list, so it stays accurate as repos get added/renamed.
+# Real trigger: "let's add all the repos using our tool to my local
+# git" (spencer@kiosk had only human-execution-engine cloned).
+clone-all-repos:
+	@mkdir -p "$(GIT_DIR)"
+	@repos="$$(gh api "orgs/$(GH_ORG)/repos?per_page=100" --jq '.[].name')"; \
+	if [ -z "$$repos" ]; then \
+		echo "bootstrap.mk: gh api returned no repos -- check gh auth status" 1>&2; \
+		exit 1; \
+	fi; \
+	for r in $$repos; do \
+		d="$(GIT_DIR)/$$r"; \
+		if [ -d "$$d/.git" ]; then \
+			echo "bootstrap.mk: $$r already cloned"; \
+		else \
+			echo "bootstrap.mk: cloning $$r ..."; \
+			gh repo clone "$(GH_ORG)/$$r" "$$d" \
+				|| echo "bootstrap.mk: FAILED to clone $$r (real error above, continuing with the rest)"; \
+		fi; \
+	done
 
 link-hee: clone-repo
 	@mkdir -p "$(BIN_DIR)"
@@ -52,3 +79,4 @@ status:
 	@echo "ORG=$(ORG) USER=$(USER)"
 	@echo "clone: $$([ -d '$(CLONE_DIR)/.git' ] && echo real || echo missing) ($(CLONE_DIR))"
 	@echo "hee:   $$(readlink -f '$(BIN_DIR)/hee' 2>/dev/null || echo missing)"
+	@echo "repos: $$(find '$(GIT_DIR)' -maxdepth 2 -name .git -type d 2>/dev/null | wc -l) cloned in $(GIT_DIR)"


### PR DESCRIPTION
Real trigger: spencer@kiosk couldn't run `hee git merge` -- diagnosed live: `hee` resolved to a manually-placed partial `~/tooling/bin/` (13 hand-copied tools) instead of a real repo clone. Real, concrete instance of fleet-ops#263 (accounts with tools half-installed instead of a clean bootstrap) -- dogfooded rather than fixed by hand.

`tooling/bootstrap.mk`: real, minimal, fully unprivileged bootstrap (`make -f tooling/bootstrap.mk ORG=tcos USER=spencer bootstrap`) -- clones the repo, symlinks `hee` onto PATH. GNU Make specifically because that's the tool Spencer's own words kept naming.

**Real bug found running it live**: the `hee` dispatcher computed `TOOL_ROOT` from its own invocation path without resolving symlinks -- a symlinked install (exactly `bootstrap.mk`'s pattern) resolved `TOOL_ROOT` to the symlink's own directory instead of the real repo, so `hee git merge` failed with `hee-git-merge: not found` even though the clone and the tool both existed. Fixed with a portable POSIX symlink-resolution loop.

**Verified end-to-end against spencer@kiosk's real account, live**: `bootstrap.mk` cloned the repo, the fixed dispatcher resolved through the real symlink, `hee git merge` ran correctly.