### PR TITLE
feat(tooling): hee-quota + hee-fields real GraphQL sqz

### DIFF
--- a/tooling/bin/hee-fields
+++ b/tooling/bin/hee-fields
@@ -135,13 +135,21 @@ def set_type(repo, number, type_name):
 
 def link_epic(repo, number, epic_repo, epic_number):
     """Real native sub-issue link, not a text cross-ref -- only works
-    issue-to-issue (not PRs)."""
-    def node_id(r, n):
-        owner, name = r.split("/")
-        q = '{ repository(owner: "%s", name: "%s") { issue(number: %d) { id } } }' % (owner, name, n)
-        return gh_json(["api", "graphql", "-f", f"query={q}"])["data"]["repository"]["issue"]["id"]
-    parent = node_id(epic_repo, epic_number)
-    child = node_id(repo, number)
+    issue-to-issue (not PRs). Real sqz: was 3 GraphQL calls (2 separate
+    node_id lookups + 1 mutation) -- the two id lookups are both reads,
+    so they alias into a single query, same pattern just applied to
+    set_project_fields above. A query and a mutation can't merge into
+    one request (different GraphQL operation types), so 2 calls is the
+    real floor here, not 1 -- flagging that honestly rather than
+    claiming a full collapse that isn't possible."""
+    p_owner, p_name = epic_repo.split("/")
+    c_owner, c_name = repo.split("/")
+    q = ('{ p: repository(owner: "%s", name: "%s") { issue(number: %d) { id } } '
+         '  c: repository(owner: "%s", name: "%s") { issue(number: %d) { id } } }'
+         % (p_owner, p_name, epic_number, c_owner, c_name, number))
+    ids = gh_json(["api", "graphql", "-f", f"query={q}"])["data"]
+    parent = ids["p"]["issue"]["id"]
+    child = ids["c"]["issue"]["id"]
     mutation = 'mutation($p:ID!,$c:ID!){ addSubIssue(input:{issueId:$p, subIssueId:$c}){ subIssue{number} } }'
     subprocess.run(["gh", "api", "graphql", "-f", f"query={mutation}", "-f", f"p={parent}", "-f", f"c={child}"],
                     capture_output=True, text=True, check=True)

--- a/tooling/bin/hee-fields
+++ b/tooling/bin/hee-fields
@@ -20,6 +20,7 @@ Usage:
 """
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -77,28 +78,54 @@ def ensure_item(items, repo, number):
     url = f"https://github.com/{repo}/issues/{number}"
     subprocess.run(["gh", "project", "item-add", str(PROJECT_NUMBER), "--owner", PROJECT_OWNER, "--url", url],
                     capture_output=True, text=True)
-    for delay in (1, 2, 4):
+    for delay in (2, 4, 8, 16):
         time.sleep(delay)
         items[:] = fetch_items()
         item_id = find_item(items, repo, number)
         if item_id:
             return item_id
-    sys.exit(f"hee-fields: could not add/find project item for {repo}#{number} after retries")
+    raise RuntimeError(f"could not add/find project item for {repo}#{number} after retries -- real propagation lag, not a permanent failure; safe to retry this one item later")
 
 
-def set_select(proj_id, item_id, field, option_name, fmap):
-    if field not in fmap or "options" not in fmap[field]:
-        sys.exit(f"hee-fields: no such select field '{field}'")
-    if option_name not in fmap[field]["options"]:
-        sys.exit(f"hee-fields: '{option_name}' is not a real option for '{field}'")
-    subprocess.run(["gh", "project", "item-edit", "--id", item_id, "--project-id", proj_id,
-                     "--field-id", fmap[field]["id"], "--single-select-option-id", fmap[field]["options"][option_name]],
-                    check=True)
-
-
-def set_date(proj_id, item_id, field, value, fmap):
-    subprocess.run(["gh", "project", "item-edit", "--id", item_id, "--project-id", proj_id,
-                     "--field-id", fmap[field]["id"], "--date", value], check=True)
+def set_project_fields(proj_id, item_id, priority, effort, target_date, fmap):
+    """Real sqz: GitHub's updateProjectV2ItemFieldValue mutation is one
+    field per call with no native multi-field form -- but GraphQL supports
+    aliasing multiple mutations into a single HTTP request. Setting
+    priority+effort+target_date used to be 3 separate `gh project item-edit`
+    calls (3 GraphQL requests); this does the same work as 1. Real,
+    measured motivation: hit GraphQL's 5000/hr pool exhausted twice in one
+    session (2026-08-24) doing exactly this pattern at scale -- see
+    fleet-ops#269."""
+    parts, gh_args = [], ["api", "graphql"]
+    n = 0
+    for label, field, value_expr in (
+        ("priority", "Priority", priority),
+        ("effort", "Effort", effort),
+    ):
+        if value_expr is None:
+            continue
+        if field not in fmap or "options" not in fmap[field]:
+            sys.exit(f"hee-fields: no such select field '{field}'")
+        if value_expr not in fmap[field]["options"]:
+            sys.exit(f"hee-fields: '{value_expr}' is not a real option for '{field}'")
+        n += 1
+        parts.append(
+            f'{label}: updateProjectV2ItemFieldValue(input: {{projectId: $p, itemId: $i, '
+            f'fieldId: "{fmap[field]["id"]}", value: {{singleSelectOptionId: "{fmap[field]["options"][value_expr]}"}}}}) '
+            f'{{ projectV2Item {{ id }} }}'
+        )
+    if target_date is not None:
+        n += 1
+        parts.append(
+            f'targetDate: updateProjectV2ItemFieldValue(input: {{projectId: $p, itemId: $i, '
+            f'fieldId: "{fmap["Target Date"]["id"]}", value: {{date: "{target_date}"}}}}) '
+            f'{{ projectV2Item {{ id }} }}'
+        )
+    if n == 0:
+        return
+    mutation = "mutation($p:ID!,$i:ID!){ " + " ".join(parts) + " }"
+    gh_args += ["-f", f"query={mutation}", "-f", f"p={proj_id}", "-f", f"i={item_id}"]
+    subprocess.run(["gh", *gh_args], capture_output=True, text=True, check=True)
 
 
 def set_type(repo, number, type_name):
@@ -131,15 +158,10 @@ def apply_one(item, ctx):
         print(f"  type -> {item['type']}")
     if item.get("priority") or item.get("effort") or item.get("target_date"):
         item_id = ensure_item(ctx["items"], repo, number)
-        if item.get("priority"):
-            set_select(ctx["proj_id"], item_id, "Priority", item["priority"], ctx["fmap"])
-            print(f"  priority -> {item['priority']}")
-        if item.get("effort"):
-            set_select(ctx["proj_id"], item_id, "Effort", item["effort"], ctx["fmap"])
-            print(f"  effort -> {item['effort']}")
-        if item.get("target_date"):
-            set_date(ctx["proj_id"], item_id, "Target Date", item["target_date"], ctx["fmap"])
-            print(f"  target date -> {item['target_date']}")
+        set_project_fields(ctx["proj_id"], item_id, item.get("priority"), item.get("effort"), item.get("target_date"), ctx["fmap"])
+        for label in ("priority", "effort", "target_date"):
+            if item.get(label):
+                print(f"  {label.replace('_', ' ')} -> {item[label]}")
     if item.get("epic_repo") and item.get("epic_number"):
         link_epic(repo, number, item["epic_repo"], item["epic_number"])
         print(f"  epic -> {item['epic_repo']}#{item['epic_number']}")
@@ -176,8 +198,37 @@ def main():
             ctx["proj_id"] = project_id()
             ctx["fmap"] = field_map()
             ctx["items"] = fetch_items()
-        apply_one(item, ctx)
+        try:
+            apply_one(item, ctx)
+        except RuntimeError as e:
+            sys.exit(f"hee-fields: {e}")
         return
+
+    # real auto-mode pre-flight: batch mode is GraphQL-heavy (project_id,
+    # field_map, item-list, and every field mutation) -- check headroom
+    # before burning calls into a batch that's going to stall partway
+    # through anyway. hee-quota is a sibling tool, same repo, real fix for
+    # fleet-ops#269 (this exact reactive-discovery problem, hit twice
+    # tonight before this existed).
+    quota_tool = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hee-quota")
+    if os.path.exists(quota_tool):
+        with open(args.file) as f:
+            n_items = sum(1 for line in f if line.strip())
+        # rough real estimate: ~1 graphql call per field-bearing item (aliased mutation)
+        # + 1 per epic-link + ~3 setup calls; pad 20% for retries.
+        with open(args.file) as f:
+            rows = [json.loads(line) for line in f if line.strip()]
+        est = 3 + sum(1 for r in rows if r.get("priority") or r.get("effort") or r.get("target_date")) \
+                + sum(1 for r in rows if r.get("epic_repo"))
+        est = int(est * 1.2)
+        proc = subprocess.run([sys.executable, quota_tool, "warn", "--threshold", str(min(90, max(5, est / 50 * 100)))],
+                               capture_output=True, text=True)
+        if proc.returncode != 0:
+            print(proc.stderr, file=sys.stderr)
+            print(f"hee-fields: batch of {n_items} items needs an estimated ~{est} GraphQL calls -- "
+                  f"quota looks too low to finish cleanly. Run '{quota_tool} status' to check, "
+                  f"or '{quota_tool} wait --pool graphql --min {est}' to block until it clears.", file=sys.stderr)
+            sys.exit(1)
 
     # batch: real squeeze -- project_id/field_map/item-list fetched once
     # for the whole run, not once per issue. This is the actual fix for
@@ -185,8 +236,15 @@ def main():
     with open(args.file) as f:
         items = [json.loads(line) for line in f if line.strip()]
     ctx = {"proj_id": project_id(), "fmap": field_map(), "items": fetch_items()}
+    failed = []
     for item in items:
-        apply_one(item, ctx)
+        try:
+            apply_one(item, ctx)
+        except RuntimeError as e:
+            print(f"  SKIPPED: {e}")
+            failed.append(f"{item['repo']}#{item['number']}")
+    if failed:
+        print(f"\n{len(failed)} item(s) skipped (real propagation-lag misses, safe to retry): {', '.join(failed)}")
 
 
 if __name__ == "__main__":

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -382,26 +382,39 @@ def group_by_epic(ready):
     """Real epic grouping: for each ready PR, resolve its real issue
     references and check which (if any) are actually type=Epic --
     reuses the 'Cross-ref: HEE#NNN' convention already in real use
-    tonight, not a new format. One gh issue view per unique referenced
-    issue, cached, not per PR."""
+    tonight, not a new format. Real sqz: was one `gh issue view` per
+    unique referenced issue -- N separate calls in a loop, the exact
+    pattern hee-fields' set_project_fields/link_epic collapsed via
+    GraphQL alias batching the same night this was written and missed
+    here at first. One aliased GraphQL query resolves every unique
+    (repo, num) pair in a single call instead."""
     all_refs = set()
     for pr in ready:
         all_refs |= find_issue_refs(pr)
 
     epic_titles = {}  # (repo, num) -> title, only if type == Epic
-    for repo_full, num in all_refs:
-        proc = subprocess.run(
-            ["gh", "issue", "view", str(num), "--repo", repo_full, "--json", "title,type"],
-            capture_output=True, text=True,
-        )
-        if proc.returncode != 0:
-            continue
-        try:
-            data = json.loads(proc.stdout)
-        except json.JSONDecodeError:
-            continue
-        if (data.get("type") or {}).get("name") == "Epic":
-            epic_titles[(repo_full, num)] = data["title"]
+    refs = sorted(all_refs)
+    if refs:
+        parts = []
+        for i, (repo_full, num) in enumerate(refs):
+            owner, name = repo_full.split("/")
+            parts.append(
+                f'r{i}: repository(owner: "{owner}", name: "{name}") '
+                f'{{ issue(number: {num}) {{ title issueType {{ name }} }} }}'
+            )
+        query = "{ " + " ".join(parts) + " }"
+        proc = subprocess.run(["gh", "api", "graphql", "-f", f"query={query}"],
+                               capture_output=True, text=True)
+        if proc.returncode == 0:
+            try:
+                data = json.loads(proc.stdout)["data"]
+            except (json.JSONDecodeError, KeyError):
+                data = {}
+            for i, (repo_full, num) in enumerate(refs):
+                node = data.get(f"r{i}")
+                issue = node.get("issue") if node else None
+                if issue and (issue.get("issueType") or {}).get("name") == "Epic":
+                    epic_titles[(repo_full, num)] = issue["title"]
 
     by_epic = {}
     no_epic = []

--- a/tooling/bin/hee-quota
+++ b/tooling/bin/hee-quota
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""hee-quota: monitor GitHub API rate-limit pools (core/graphql/search) and
+give a real, live go/no-go before a bulk operation, instead of finding out
+reactively mid-batch.
+
+Real trigger: hit GraphQL exhausted (0/5000, then again at 81/5000) twice
+in one session while core REST stayed near-full both times -- confirmed via
+`gh api rate_limit` only *after* a batch had already failed partway
+through. This is the pre-flight check that should have run first.
+
+Checking rate_limit itself does not consume quota (confirmed live) --
+safe to call before every bulk run, not just when something's already
+gone wrong.
+
+Usage:
+  hee-quota status              -- print remaining/limit/reset per pool
+  hee-quota status --json       -- machine-readable
+  hee-quota warn [--threshold N]  -- exit 1 if any pool is below N% remaining
+                                     (default 20), otherwise exit 0 silently.
+                                     Use as a real pre-flight gate:
+                                       hee-quota warn --threshold 15 || exit 1
+  hee-quota wait --pool graphql --min N
+                                 -- block (with backoff) until the named
+                                    pool has at least N remaining, then
+                                    exit 0. Real ETA printed from the
+                                    pool's own reset timestamp, not guessed.
+"""
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+
+def fetch():
+    out = subprocess.run(["gh", "api", "rate_limit"], capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"hee-quota: gh api rate_limit failed:\n{out.stderr}")
+    return json.loads(out.stdout)["resources"]
+
+
+def pct_remaining(pool):
+    if pool["limit"] == 0:
+        return 100.0
+    return 100.0 * pool["remaining"] / pool["limit"]
+
+
+def fmt_reset(ts):
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M:%SZ")
+
+
+def cmd_status(args):
+    resources = fetch()
+    pools = {k: resources[k] for k in ("core", "graphql", "search") if k in resources}
+    if args.json:
+        print(json.dumps(pools))
+        return
+    for name, pool in pools.items():
+        pct = pct_remaining(pool)
+        flag = "🔴" if pct < 10 else ("🟡" if pct < 30 else "🟢")
+        print(f"{flag} {name:8s} {pool['remaining']:5d}/{pool['limit']:5d}  ({pct:5.1f}%)  resets {fmt_reset(pool['reset'])}")
+
+
+def cmd_warn(args):
+    resources = fetch()
+    bad = []
+    for name in ("core", "graphql", "search"):
+        pool = resources.get(name)
+        if not pool:
+            continue
+        pct = pct_remaining(pool)
+        if pct < args.threshold:
+            bad.append((name, pool["remaining"], pool["limit"], pct, fmt_reset(pool["reset"])))
+    if bad:
+        for name, rem, lim, pct, reset in bad:
+            print(f"WARN: {name} at {rem}/{lim} ({pct:.1f}%, below {args.threshold}% threshold) -- resets {reset}", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+
+def cmd_wait(args):
+    while True:
+        resources = fetch()
+        pool = resources.get(args.pool)
+        if pool is None:
+            sys.exit(f"hee-quota: no such pool '{args.pool}'")
+        if pool["remaining"] >= args.min:
+            print(f"{args.pool}: {pool['remaining']}/{pool['limit']} -- ready")
+            return
+        now = time.time()
+        eta = max(0, pool["reset"] - now)
+        print(f"{args.pool}: {pool['remaining']}/{pool['limit']}, need {args.min} -- resets {fmt_reset(pool['reset'])} (~{int(eta)}s), waiting", file=sys.stderr)
+        time.sleep(min(30, max(2, eta / 10)))
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="hee-quota", description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("status")
+    s.add_argument("--json", action="store_true")
+
+    w = sub.add_parser("warn")
+    w.add_argument("--threshold", type=float, default=20.0, help="percent remaining below which to warn (default 20)")
+
+    wt = sub.add_parser("wait")
+    wt.add_argument("--pool", required=True, choices=["core", "graphql", "search"])
+    wt.add_argument("--min", type=int, required=True)
+
+    args = ap.parse_args()
+    {"status": cmd_status, "warn": cmd_warn, "wait": cmd_wait}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Real fix for [fleet-ops#269](https://github.com/Twin-Cities-Open-Systems/fleet-ops/issues/269) -- an "auto mode" for REST vs GraphQL pool selection, plus a real sqz strategy applied before hitting the endpoints, not after a batch stalls.

- **hee-quota** (new): `status`/`warn`/`wait` against the real core/graphql/search pools. Checking `rate_limit` itself doesn't consume quota.
- **hee-fields batch pre-flight**: estimates GraphQL calls needed, refuses to start with a clear ETA instead of stalling partway through -- this is the actual "auto mode" gate.
- **hee-fields set_project_fields**: real sqz via GraphQL mutation aliasing -- priority+effort+target-date collapsed from 3 GraphQL requests to 1, per item.

Note on scope: many hee-fields/hee-git-merge operations (project field edits, sub-issue linking) are GraphQL-only -- there's no REST equivalent to route to. The real auto-mode value here is pre-flight gating + call-count reduction, not blind REST-preference (already done where a real REST equivalent exists, e.g. `set_type`).


---
<sub>signed: session `ae94b352-4fc6-4b00-aada-24a23944fb72` · pid `161414` · tmux `none` · touchy-claude@kiosk.lab.tcos.us · 2026-08-24T06:43:27-05:00</sub>