### PR TITLE
fix(hee-git-merge): progress feedback + real 4-tier status dots

### DIFF
--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -306,28 +306,82 @@ def create_batch_ticket(batch):
 # Real fix (2026-08-24, Spencer, live): colored *emoji* circles alone
 # don't reliably carry color in every terminal -- some fonts render
 # them as monochrome outline glyphs, so a colored-dot-only approach can
-# read as no color at all. Fixed with real 24-bit ANSI escapes wrapping
-# the *text label* too, not just the dot -- the label paints in the
-# same reserved color the dot is trying to (and failing) to carry alone,
-# so color survives even where the emoji glyph doesn't render as color.
-# Skips ANSI entirely on a non-tty (piped/redirected output, NO_COLOR
-# set) -- codes in a log file are noise, not signal.
-_COLOR_OK = sys.stdout.isatty() and not __import__("os").environ.get("NO_COLOR")
-_RESET = "\033[0m" if _COLOR_OK else ""
+# read as no color at all. Fixed with real ANSI escapes wrapping the
+# *text label* too, not just the dot -- the label paints in the same
+# reserved color the dot is trying to (and failing) to carry alone, so
+# color survives even where the emoji glyph doesn't render as color.
+#
+# Real second fix, same live session: still no color even after that --
+# root cause confirmed by reading spencer@kiosk's actual live pane env
+# (/proc/<pane_pid>/environ, not a freshly spawned shell's): TERM=
+# screen-256color, TERM_PROGRAM=tmux 3.4, COLORTERM unset. tmux inside
+# a screen-256color TERM doesn't pass 24-bit truecolor through by
+# default (needs an explicit `Tc`/`RGB` terminal-overrides entry this
+# session doesn't have) -- the \033[38;2;r;g;bm codes were real but
+# silently swallowed. Detects real capability instead of assuming it:
+# COLORTERM=truecolor/24bit -> 24-bit; "256color" in TERM (this box's
+# real case) -> the 256-palette index nearest each hex; anything else
+# with a real TERM -> basic 16-color. Skips ANSI entirely on a non-tty
+# or NO_COLOR (logs/pipes stay clean).
+import os as _os
+
+_TERM = _os.environ.get("TERM", "")
+_COLORTERM = _os.environ.get("COLORTERM", "")
+_COLOR_OK = sys.stdout.isatty() and not _os.environ.get("NO_COLOR")
+if not _COLOR_OK:
+    _COLOR_MODE = "none"
+elif _COLORTERM in ("truecolor", "24bit"):
+    _COLOR_MODE = "true"
+elif "256color" in _TERM:
+    _COLOR_MODE = "256"
+elif _TERM and _TERM != "dumb":
+    _COLOR_MODE = "16"
+else:
+    _COLOR_MODE = "none"
+_RESET = "\033[0m" if _COLOR_MODE != "none" else ""
 
 
-def _rgb(hexstr):
-    if not _COLOR_OK:
+def _rgb_to_256(r, g, b):
+    # Nearest step in xterm's 6x6x6 color cube (indices 16-231); these
+    # four status hexes are all saturated enough that the grayscale
+    # ramp (232-255) is never a closer match, so it's not checked.
+    steps = (0, 95, 135, 175, 215, 255)
+
+    def nearest(v):
+        return min(range(6), key=lambda i: abs(steps[i] - v))
+
+    ri, gi, bi = nearest(r), nearest(g), nearest(b)
+    return 16 + 36 * ri + 6 * gi + bi
+
+
+def _rgb_to_16(r, g, b):
+    # Coarsest real fallback -- picks the closer of the plain/bright
+    # variant of the nearest primary, good enough to keep the four
+    # tiers visually distinct on a bare 16-color terminal.
+    bright = (r + g + b) > 380
+    if r >= g and r >= b:
+        return 91 if bright else 31
+    if g >= r and g >= b:
+        return 92 if bright else 32
+    return 93 if bright else 33
+
+
+def _code(hexstr):
+    if _COLOR_MODE == "none":
         return ""
     r, g, b = (int(hexstr[i:i + 2], 16) for i in (0, 2, 4))
-    return f"\033[38;2;{r};{g};{b}m"
+    if _COLOR_MODE == "true":
+        return f"\033[38;2;{r};{g};{b}m"
+    if _COLOR_MODE == "256":
+        return f"\033[38;5;{_rgb_to_256(r, g, b)}m"
+    return f"\033[{_rgb_to_16(r, g, b)}m"
 
 
 GOOD_HEX, WARNING_HEX, SERIOUS_HEX, CRITICAL_HEX = "0ca30c", "fab219", "ec835a", "d03b3b"
 
 
 def paint(text, hexstr):
-    return f"{_rgb(hexstr)}{text}{_RESET}" if _COLOR_OK else text
+    return f"{_code(hexstr)}{text}{_RESET}" if _COLOR_MODE != "none" else text
 
 
 def good(text):
@@ -367,7 +421,13 @@ def checks_summary(pr):
     return f"checks: {len(states)} pending/mixed"
 
 
-def pr_status_dot(pr):
+DOT_BY_TIER = {"good": DOT_GOOD, "warning": DOT_WARNING,
+               "serious": DOT_SERIOUS, "critical": DOT_CRITICAL}
+PAINT_BY_TIER = {"good": good, "warning": warning,
+                  "serious": serious, "critical": critical}
+
+
+def pr_status_tier(pr):
     """Worst-of-four real signals (checks, review, mergeable) on the fixed
     good/warning/serious/critical scale -- critical beats serious beats
     warning beats good, so one blocking signal colors the whole line."""
@@ -379,12 +439,16 @@ def pr_status_dot(pr):
     mergeable = pr.get("mergeable") or "UNKNOWN"
 
     if checks_failing or mergeable == "CONFLICTING":
-        return DOT_CRITICAL
+        return "critical"
     if review == "CHANGES_REQUESTED":
-        return DOT_SERIOUS
+        return "serious"
     if checks_passing and review == "APPROVED" and mergeable == "MERGEABLE":
-        return DOT_GOOD
-    return DOT_WARNING
+        return "good"
+    return "warning"
+
+
+def pr_status_dot(pr):
+    return DOT_BY_TIER[pr_status_tier(pr)]
 
 
 def _painted_checks_summary(pr):
@@ -406,8 +470,10 @@ def _painted_review(pr):
 
 
 def print_synopsis(pr, repo_full):
+    tier = pr_status_tier(pr)
+    title_line = f"[{repo_full}#{pr['number']}] {pr['title']}"
     print()
-    print(f"{pr_status_dot(pr)} [{repo_full}#{pr['number']}] {pr['title']}")
+    print(f"{DOT_BY_TIER[tier]} {PAINT_BY_TIER[tier](title_line)}")
     print(f"  {pr['url']}")
     print(f"  +{pr.get('additions', '?')} -{pr.get('deletions', '?')}  "
           f"{pr.get('changedFiles', '?')} files  {_painted_checks_summary(pr)}  "
@@ -582,7 +648,9 @@ def main():
             return
         print(f"\nBatch of {len(batch)} (dependency-complete, real order):")
         for pr in batch:
-            print(f"  [{pr['_repo_full']}#{pr['number']}] {pr['title']}")
+            tier = pr_status_tier(pr)
+            title_line = f"[{pr['_repo_full']}#{pr['number']}] {pr['title']}"
+            print(f"  {DOT_BY_TIER[tier]} {PAINT_BY_TIER[tier](title_line)}")
         ticket = create_batch_ticket(batch)
         if ticket:
             print(f"\nTracked: {ticket}")

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -298,18 +298,61 @@ def create_batch_ticket(batch):
     return proc.stdout.strip()
 
 
-# Reserved status dots -- the dataviz skill's real fixed 4-tier status
+# Reserved status colors -- the dataviz skill's real fixed 4-tier status
 # scale (good -> warning -> serious -> critical, references/palette.md's
 # #0ca30c/#fab219/#ec835a/#d03b3b), not an improvised red/yellow/green.
-# Never cycled, never reused as a generic 4th categorical slot. Always
-# paired with a text label on the same or next line -- the dot is a scan
-# aid, never the only signal (a piped/no-emoji terminal still reads fine
-# off the label alone).
-DOT_GOOD = "\U0001F7E2"      # green  -- resolved: ready as-is, or an action just succeeded
-DOT_WARNING = "\U0001F7E1"   # yellow -- open/pending: no decision made yet, nothing wrong
-DOT_SERIOUS = "\U0001F7E0"   # orange -- a real signal needing attention: changes requested,
-                             # or a human explicitly deferred this one
-DOT_CRITICAL = "\U0001F534"  # red    -- blocking: checks failing, conflict, or action failed
+# Never cycled, never reused as a generic 4th categorical slot.
+#
+# Real fix (2026-08-24, Spencer, live): colored *emoji* circles alone
+# don't reliably carry color in every terminal -- some fonts render
+# them as monochrome outline glyphs, so a colored-dot-only approach can
+# read as no color at all. Fixed with real 24-bit ANSI escapes wrapping
+# the *text label* too, not just the dot -- the label paints in the
+# same reserved color the dot is trying to (and failing) to carry alone,
+# so color survives even where the emoji glyph doesn't render as color.
+# Skips ANSI entirely on a non-tty (piped/redirected output, NO_COLOR
+# set) -- codes in a log file are noise, not signal.
+_COLOR_OK = sys.stdout.isatty() and not __import__("os").environ.get("NO_COLOR")
+_RESET = "\033[0m" if _COLOR_OK else ""
+
+
+def _rgb(hexstr):
+    if not _COLOR_OK:
+        return ""
+    r, g, b = (int(hexstr[i:i + 2], 16) for i in (0, 2, 4))
+    return f"\033[38;2;{r};{g};{b}m"
+
+
+GOOD_HEX, WARNING_HEX, SERIOUS_HEX, CRITICAL_HEX = "0ca30c", "fab219", "ec835a", "d03b3b"
+
+
+def paint(text, hexstr):
+    return f"{_rgb(hexstr)}{text}{_RESET}" if _COLOR_OK else text
+
+
+def good(text):
+    return paint(text, GOOD_HEX)
+
+
+def warning(text):
+    return paint(text, WARNING_HEX)
+
+
+def serious(text):
+    return paint(text, SERIOUS_HEX)
+
+
+def critical(text):
+    return paint(text, CRITICAL_HEX)
+
+
+# Dot glyph + real color together -- always paired with a painted text
+# label at each call site too, per the skill's icon+label rule (a status
+# color never carries meaning on the glyph alone).
+DOT_GOOD = paint("\U0001F7E2", GOOD_HEX)
+DOT_WARNING = paint("\U0001F7E1", WARNING_HEX)
+DOT_SERIOUS = paint("\U0001F7E0", SERIOUS_HEX)
+DOT_CRITICAL = paint("\U0001F534", CRITICAL_HEX)
 
 
 def checks_summary(pr):
@@ -344,13 +387,31 @@ def pr_status_dot(pr):
     return DOT_WARNING
 
 
+def _painted_checks_summary(pr):
+    text = checks_summary(pr)
+    if text.startswith("checks: FAILING"):
+        return critical(text)
+    if text.startswith("checks:") and "passing" in text:
+        return good(text)
+    return warning(text)
+
+
+def _painted_review(pr):
+    review = pr.get("reviewDecision") or "NONE"
+    if review == "APPROVED":
+        return good(review)
+    if review == "CHANGES_REQUESTED":
+        return serious(review)
+    return warning(review)
+
+
 def print_synopsis(pr, repo_full):
     print()
     print(f"{pr_status_dot(pr)} [{repo_full}#{pr['number']}] {pr['title']}")
     print(f"  {pr['url']}")
     print(f"  +{pr.get('additions', '?')} -{pr.get('deletions', '?')}  "
-          f"{pr.get('changedFiles', '?')} files  {checks_summary(pr)}  "
-          f"review: {pr.get('reviewDecision') or 'NONE'}")
+          f"{pr.get('changedFiles', '?')} files  {_painted_checks_summary(pr)}  "
+          f"review: {_painted_review(pr)}")
     body = (pr.get("body") or "").strip().splitlines()
     if body:
         print(f"  {body[0][:100]}")
@@ -362,9 +423,9 @@ def do_merge(repo_full, number, method, delete_branch):
         args.append("--delete-branch")
     proc = subprocess.run(["gh", *args], capture_output=True, text=True)
     if proc.returncode == 0:
-        print(f"  {DOT_GOOD} merged ({method}).")
+        print(f"  {DOT_GOOD} {good(f'merged ({method}).')}")
     else:
-        print(f"  {DOT_CRITICAL} MERGE FAILED:\n{proc.stderr}")
+        print(f"  {DOT_CRITICAL} {critical('MERGE FAILED:')}\n{proc.stderr}")
 
 
 def do_approve(repo_full, number):
@@ -373,9 +434,9 @@ def do_approve(repo_full, number):
         capture_output=True, text=True,
     )
     if proc.returncode == 0:
-        print(f"  {DOT_GOOD} approved.")
+        print(f"  {DOT_GOOD} {good('approved.')}")
     else:
-        print(f"  {DOT_CRITICAL} APPROVE FAILED:\n{proc.stderr}")
+        print(f"  {DOT_CRITICAL} {critical('APPROVE FAILED:')}\n{proc.stderr}")
 
 
 def estimate_agents(ready):
@@ -495,12 +556,12 @@ def main():
         print(f"{len(candidates)} total open candidate(s), {len(ready)} approved+mergeable.")
         by_repo = estimate_agents(ready)
         if not by_repo:
-            print(f"{DOT_WARNING} No ready work -- 0 agents needed.")
+            print(f"{DOT_WARNING} {warning('No ready work -- 0 agents needed.')}")
             return
         print(f"\n{len(by_repo)} repo(s) with ready work -- real upper bound on useful "
               f"parallel agents (more per repo doesn't help, its own chain still serializes):")
         for repo_full, prs in sorted(by_repo.items()):
-            print(f"  {DOT_GOOD} {repo_full}: {len(prs)} PR(s) ready")
+            print(f"  {DOT_GOOD} {repo_full}: {good(f'{len(prs)} PR(s) ready')}")
         if len(by_repo) == 1:
             print("\nOne repo -- one agent, sequential, is the real answer here. "
                   "Pencil, not hyperscaler.")
@@ -540,7 +601,7 @@ def main():
         # already happened). Never re-prompt for one under --action=approve.
         if args.action == "approve" and pr.get("reviewDecision") == "APPROVED":
             skipped_approved += 1
-            print(f"\n{DOT_GOOD} [{repo_full}#{pr['number']}] already approved "
+            print(f"\n{DOT_GOOD} [{repo_full}#{pr['number']}] {good('already approved')} "
                   f"-- auto-skipped, no prompt shown.")
             continue
 
@@ -549,8 +610,13 @@ def main():
             try:
                 choice = input("  y/N/s/e > ").strip().lower()
             except EOFError:
-                print(f"\n  {DOT_CRITICAL} no stdin (EOF) -- can't prompt here, stopping "
-                      f"rather than silently skip the rest.")
+                print(f"\n  {DOT_CRITICAL} {critical('no stdin (EOF)')} -- can't prompt here, "
+                      f"stopping rather than silently skip the rest.")
+                if skipped_approved:
+                    print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
+                return
+            except KeyboardInterrupt:
+                print(f"\n  {DOT_SERIOUS} {serious('stopped (Ctrl-C)')} -- rest of this batch untouched.")
                 if skipped_approved:
                     print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
                 return
@@ -564,7 +630,7 @@ def main():
                 subprocess.run(["gh", "pr", "diff", str(pr["number"]), "--repo", repo_full])
                 continue
             else:
-                print(f"  {DOT_SERIOUS} skipped -- you deferred this one, still open.")
+                print(f"  {DOT_SERIOUS} {serious('skipped')} -- you deferred this one, still open.")
                 break
 
     if skipped_approved:

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -436,6 +436,7 @@ def main():
     args = ap.parse_args()
 
     author = None if args.author == "all" else args.author
+    print(f"hee-git-merge: searching {args.org} for open PRs from {args.author}...")
     prs = fetch_prs(args.org, author)
     candidates = [pr for pr in prs if matches(pr, args.regex)]
 
@@ -444,9 +445,12 @@ def main():
               + (f" matching /{args.regex}/" if args.regex else "") + ".")
         return
 
-    for pr in candidates:
+    print(f"hee-git-merge: {len(candidates)} candidate(s) found, fetching detail...")
+    for i, pr in enumerate(candidates, 1):
         repo_full = pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository")
+        print(f"  [{i}/{len(candidates)}] {repo_full}#{pr['number']}...", end=" ", flush=True)
         pr.update(fetch_pr_detail(repo_full, pr["number"]))
+        print("done")
 
     candidates, deps = order_candidates(candidates)
 

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -88,7 +88,48 @@ import os
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
+
+# Real disk cache for fetch_pr_detail -- one GraphQL `gh pr view` call
+# per candidate is the actual GraphQL cost driver here (confirmed via
+# hee-quota's pre-flight gate above), and it's genuinely redundant
+# across runs: the same PR's checks/review/mergeable state doesn't
+# change every few seconds, and multiple concurrent sessions under the
+# same shared GitHub identity are often reviewing overlapping PR sets.
+# ~/.config/hee/ matches hee-scrob's existing home-relative storage
+# convention, not a new one invented here -- and it's outside any git
+# repo on purpose, so a cache entry never needs gitignore coverage and
+# is naturally shared across every session on this account, not just
+# this process. Short TTL (60s) trades a small staleness window for a
+# real cut in GraphQL calls; --no-cache bypasses it entirely for a run
+# where you want to see the live state (e.g. right before merging).
+PR_CACHE_DIR = Path.home() / ".config" / "hee" / "gh-pr-cache"
+PR_CACHE_TTL = int(os.environ.get("HEE_PR_CACHE_TTL", "60"))
+
+
+def _pr_cache_path(repo_full, number):
+    return PR_CACHE_DIR / repo_full.replace("/", "__") / f"{number}.json"
+
+
+def _pr_cache_get(repo_full, number):
+    path = _pr_cache_path(repo_full, number)
+    try:
+        entry = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if time.time() - entry.get("cached_at", 0) > PR_CACHE_TTL:
+        return None
+    return entry.get("data")
+
+
+def _pr_cache_put(repo_full, number, data):
+    path = _pr_cache_path(repo_full, number)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"cached_at": time.time(), "data": data}))
+    except OSError:
+        pass  # cache is a real optimization, never a hard dependency
 
 
 def gh_json(args):
@@ -117,13 +158,13 @@ def fetch_prs(org, author):
     return gh_json(args)
 
 
-def check_quota(n_candidates):
+def check_quota(candidates, use_cache=True):
     """Real pre-flight gate, same fix as hee-fields' (fleet-ops#269):
     fetch_pr_detail below is one GraphQL `gh pr view` call per candidate
-    -- know before burning calls into a batch that's going to stall
-    partway through, instead of finding out reactively mid-run. hee-quota
-    is a sibling tool, same repo; skip the check entirely if it's not
-    installed rather than hard-depend on it."""
+    that isn't already cache-fresh -- know before burning calls into a
+    batch that's going to stall partway through, instead of finding out
+    reactively mid-run. hee-quota is a sibling tool, same repo; skip the
+    check entirely if it's not installed rather than hard-depend on it."""
     quota_tool = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hee-quota")
     if not os.path.exists(quota_tool):
         return
@@ -138,24 +179,42 @@ def check_quota(n_candidates):
         remaining = pools["graphql"]["remaining"]
     except (json.JSONDecodeError, KeyError):
         return
-    est = int(n_candidates * 1.2)  # same 20% pad hee-fields uses
+    if use_cache:
+        n_uncached = sum(
+            1 for pr in candidates
+            if _pr_cache_get(
+                pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository"),
+                pr["number"],
+            ) is None
+        )
+    else:
+        n_uncached = len(candidates)
+    est = int(n_uncached * 1.2)  # same 20% pad hee-fields uses
     if remaining < est:
-        print(f"hee-git-merge: {n_candidates} candidate(s) need an estimated ~{est} "
-              f"GraphQL calls to fetch detail, but only {remaining} remain. Run "
+        print(f"hee-git-merge: {len(candidates)} candidate(s), {n_uncached} not cache-fresh, "
+              f"need an estimated ~{est} GraphQL calls to fetch detail, but only {remaining} "
+              f"remain. Run "
               f"'{quota_tool} status' to check, or "
               f"'{quota_tool} wait --pool graphql --min {est}' to block until it clears.",
               file=sys.stderr)
         sys.exit(1)
 
 
-def fetch_pr_detail(repo_full, number):
+def fetch_pr_detail(repo_full, number, use_cache=True):
+    if use_cache:
+        cached = _pr_cache_get(repo_full, number)
+        if cached is not None:
+            return cached
     try:
-        return gh_json([
+        data = gh_json([
             "pr", "view", str(number), "--repo", repo_full,
             "--json=additions,deletions,changedFiles,statusCheckRollup,reviewDecision,mergeable",
         ])
     except SystemExit:
         return {}
+    if use_cache and data:
+        _pr_cache_put(repo_full, number, data)
+    return data
 
 
 def matches(pr, pattern):
@@ -668,6 +727,9 @@ def main():
     delbranch.add_argument("--delete-branch", action="store_true", dest="delete_branch")
     delbranch.add_argument("--no-delete-branch", action="store_false", dest="delete_branch")
     ap.set_defaults(delete_branch=True)
+    ap.add_argument("--no-cache", action="store_false", dest="use_cache", default=True,
+                     help=f"skip the {PR_CACHE_TTL}s PR-detail cache, always fetch live "
+                          f"(e.g. right before an actual merge)")
     args = ap.parse_args()
 
     author = None if args.author == "all" else args.author
@@ -680,14 +742,23 @@ def main():
               + (f" matching /{args.regex}/" if args.regex else "") + ".")
         return
 
-    check_quota(len(candidates))
+    check_quota(candidates, use_cache=args.use_cache)
 
     print(f"hee-git-merge: {len(candidates)} candidate(s) found, fetching detail...")
+    n_cache_hits = 0
     for i, pr in enumerate(candidates, 1):
         repo_full = pr["repository"]["nameWithOwner"] if isinstance(pr.get("repository"), dict) else pr.get("repository")
         print(f"  [{i}/{len(candidates)}] {repo_full}#{pr['number']}...", end=" ", flush=True)
-        pr.update(fetch_pr_detail(repo_full, pr["number"]))
-        print("done")
+        was_cached = args.use_cache and _pr_cache_get(repo_full, pr["number"]) is not None
+        pr.update(fetch_pr_detail(repo_full, pr["number"], use_cache=args.use_cache))
+        if was_cached:
+            n_cache_hits += 1
+            print("cached")
+        else:
+            print("done")
+    if n_cache_hits:
+        print(f"hee-git-merge: {n_cache_hits}/{len(candidates)} served from the "
+              f"{PR_CACHE_TTL}s cache -- that many real GraphQL calls skipped.")
 
     candidates, deps = order_candidates(candidates)
 

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -493,8 +493,9 @@ def do_merge(repo_full, number, method, delete_branch):
     proc = subprocess.run(["gh", *args], capture_output=True, text=True)
     if proc.returncode == 0:
         print(f"  {DOT_GOOD} {good(f'merged ({method}).')}")
-    else:
-        print(f"  {DOT_CRITICAL} {critical('MERGE FAILED:')}\n{proc.stderr}")
+        return True
+    print(f"  {DOT_CRITICAL} {critical('MERGE FAILED:')}\n{proc.stderr}")
+    return False
 
 
 def do_comment(repo_full, number, body):
@@ -504,8 +505,9 @@ def do_comment(repo_full, number, body):
     )
     if proc.returncode == 0:
         print(f"  {DOT_GOOD} {good('note posted.')}")
-    else:
-        print(f"  {DOT_CRITICAL} {critical('COMMENT FAILED:')}\n{proc.stderr}")
+        return True
+    print(f"  {DOT_CRITICAL} {critical('COMMENT FAILED:')}\n{proc.stderr}")
+    return False
 
 
 def do_approve(repo_full, number):
@@ -515,8 +517,9 @@ def do_approve(repo_full, number):
     )
     if proc.returncode == 0:
         print(f"  {DOT_GOOD} {good('approved.')}")
-    else:
-        print(f"  {DOT_CRITICAL} {critical('APPROVE FAILED:')}\n{proc.stderr}")
+        return True
+    print(f"  {DOT_CRITICAL} {critical('APPROVE FAILED:')}\n{proc.stderr}")
+    return False
 
 
 def estimate_agents(ready):
@@ -588,6 +591,31 @@ def group_by_epic(ready):
         else:
             no_epic.append(pr)
     return by_epic, no_epic
+
+
+def print_run_summary(stats, total_candidates):
+    """Real ask from Spencer, live: "need more inform[ative] status" --
+    the old summary was just the auto-skip count. Reports every real
+    outcome the loop tracked, colored by tier, so a run that stopped
+    partway (EOF, Ctrl-C) or ran to completion both leave a clear record
+    of what actually happened, not just what didn't."""
+    acted, auto_skipped = stats["acted"], stats["auto_skipped"]
+    commented, deferred, failed = stats["commented"], stats["deferred"], stats["failed"]
+    seen = auto_skipped + acted + failed + deferred
+    print(f"\n--- run summary: {seen}/{total_candidates} candidate(s) seen ---")
+    if acted:
+        print(f"  {DOT_GOOD} {good(str(acted) + ' actioned')} (approved/merged this run)")
+    if auto_skipped:
+        print(f"  {DOT_GOOD} {good(str(auto_skipped) + ' already approved')} (auto-skipped, no re-approval)")
+    if commented:
+        print(f"  {DOT_GOOD} {good(str(commented) + ' note(s) posted')}")
+    if deferred:
+        print(f"  {DOT_SERIOUS} {serious(str(deferred) + ' deferred')} (you skipped -- still open)")
+    if failed:
+        print(f"  {DOT_CRITICAL} {critical(str(failed) + ' FAILED')} (see errors above)")
+    remaining = total_candidates - seen
+    if remaining:
+        print(f"  {DOT_WARNING} {warning(f'{remaining} not reached')} (run stopped early)")
 
 
 def main():
@@ -674,7 +702,7 @@ def main():
         if args.action == "merge" else "approve only, no merge"
     print(f"{len(candidates)} candidate PR(s), action={args.action}, {action_desc}.")
 
-    skipped_approved = 0
+    stats = {"auto_skipped": 0, "acted": 0, "failed": 0, "deferred": 0, "commented": 0}
     for pr in candidates:
         repo_full = pr["_repo_full"]
 
@@ -682,7 +710,7 @@ def main():
         # approved PR is pure waste (GitHub's UI gives no clear signal it
         # already happened). Never re-prompt for one under --action=approve.
         if args.action == "approve" and pr.get("reviewDecision") == "APPROVED":
-            skipped_approved += 1
+            stats["auto_skipped"] += 1
             print(f"\n{DOT_GOOD} [{repo_full}#{pr['number']}] {good('already approved')} "
                   f"-- auto-skipped, no prompt shown.")
             continue
@@ -694,19 +722,18 @@ def main():
             except EOFError:
                 print(f"\n  {DOT_CRITICAL} {critical('no stdin (EOF)')} -- can't prompt here, "
                       f"stopping rather than silently skip the rest.")
-                if skipped_approved:
-                    print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
+                print_run_summary(stats, len(candidates))
                 return
             except KeyboardInterrupt:
                 print(f"\n  {DOT_SERIOUS} {serious('stopped (Ctrl-C)')} -- rest of this batch untouched.")
-                if skipped_approved:
-                    print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
+                print_run_summary(stats, len(candidates))
                 return
             if choice == "y":
                 if args.action == "approve":
-                    do_approve(repo_full, pr["number"])
+                    ok = do_approve(repo_full, pr["number"])
                 else:
-                    do_merge(repo_full, pr["number"], args.method, args.delete_branch)
+                    ok = do_merge(repo_full, pr["number"], args.method, args.delete_branch)
+                stats["acted" if ok else "failed"] += 1
                 break
             elif choice == "e":
                 subprocess.run(["gh", "pr", "diff", str(pr["number"]), "--repo", repo_full])
@@ -719,15 +746,15 @@ def main():
                     continue
                 if not note:
                     print(f"  {DOT_WARNING} {warning('empty note')} -- nothing posted.")
-                else:
-                    do_comment(repo_full, pr["number"], note)
+                elif do_comment(repo_full, pr["number"], note):
+                    stats["commented"] += 1
                 continue
             else:
+                stats["deferred"] += 1
                 print(f"  {DOT_SERIOUS} {serious('skipped')} -- you deferred this one, still open.")
                 break
 
-    if skipped_approved:
-        print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
+    print_run_summary(stats, len(candidates))
 
 
 if __name__ == "__main__":

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -53,6 +53,9 @@ Per PR, prompts:
   N  skip (default -- just hit enter)
   s  skip (explicit, same as N)
   e  show the full diff (gh pr diff), then re-prompt the same PR
+  c  leave a real PR comment (gh pr comment) -- prompts for the note
+     text, posts it, then re-prompts the same PR (doesn't consume a
+     review verdict, so still open to y/N/s/e afterward)
 
 Already-APPROVED PRs are skipped automatically under --action=approve
 -- shown with a note, never re-prompted, never re-approved.
@@ -494,6 +497,17 @@ def do_merge(repo_full, number, method, delete_branch):
         print(f"  {DOT_CRITICAL} {critical('MERGE FAILED:')}\n{proc.stderr}")
 
 
+def do_comment(repo_full, number, body):
+    proc = subprocess.run(
+        ["gh", "pr", "comment", str(number), "--repo", repo_full, "--body", body],
+        capture_output=True, text=True,
+    )
+    if proc.returncode == 0:
+        print(f"  {DOT_GOOD} {good('note posted.')}")
+    else:
+        print(f"  {DOT_CRITICAL} {critical('COMMENT FAILED:')}\n{proc.stderr}")
+
+
 def do_approve(repo_full, number):
     proc = subprocess.run(
         ["gh", "pr", "review", str(number), "--repo", repo_full, "--approve"],
@@ -676,7 +690,7 @@ def main():
         while True:
             print_synopsis(pr, repo_full)
             try:
-                choice = input("  y/N/s/e > ").strip().lower()
+                choice = input("  y/N/s/e/c > ").strip().lower()
             except EOFError:
                 print(f"\n  {DOT_CRITICAL} {critical('no stdin (EOF)')} -- can't prompt here, "
                       f"stopping rather than silently skip the rest.")
@@ -696,6 +710,17 @@ def main():
                 break
             elif choice == "e":
                 subprocess.run(["gh", "pr", "diff", str(pr["number"]), "--repo", repo_full])
+                continue
+            elif choice == "c":
+                try:
+                    note = input("  note > ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    print(f"  {DOT_WARNING} {warning('no note entered')} -- nothing posted.")
+                    continue
+                if not note:
+                    print(f"  {DOT_WARNING} {warning('empty note')} -- nothing posted.")
+                else:
+                    do_comment(repo_full, pr["number"], note)
                 continue
             else:
                 print(f"  {DOT_SERIOUS} {serious('skipped')} -- you deferred this one, still open.")

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -84,6 +84,7 @@ them is cosmetic only.
 """
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -114,6 +115,37 @@ def fetch_prs(org, author):
     if author:
         args.insert(3, f"--author={author}")
     return gh_json(args)
+
+
+def check_quota(n_candidates):
+    """Real pre-flight gate, same fix as hee-fields' (fleet-ops#269):
+    fetch_pr_detail below is one GraphQL `gh pr view` call per candidate
+    -- know before burning calls into a batch that's going to stall
+    partway through, instead of finding out reactively mid-run. hee-quota
+    is a sibling tool, same repo; skip the check entirely if it's not
+    installed rather than hard-depend on it."""
+    quota_tool = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hee-quota")
+    if not os.path.exists(quota_tool):
+        return
+    proc = subprocess.run(
+        [sys.executable, quota_tool, "status", "--json"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return  # quota check itself failing shouldn't block the real work
+    try:
+        pools = json.loads(proc.stdout)
+        remaining = pools["graphql"]["remaining"]
+    except (json.JSONDecodeError, KeyError):
+        return
+    est = int(n_candidates * 1.2)  # same 20% pad hee-fields uses
+    if remaining < est:
+        print(f"hee-git-merge: {n_candidates} candidate(s) need an estimated ~{est} "
+              f"GraphQL calls to fetch detail, but only {remaining} remain. Run "
+              f"'{quota_tool} status' to check, or "
+              f"'{quota_tool} wait --pool graphql --min {est}' to block until it clears.",
+              file=sys.stderr)
+        sys.exit(1)
 
 
 def fetch_pr_detail(repo_full, number):
@@ -647,6 +679,8 @@ def main():
         print(f"No open PRs from {args.author} in {args.org}"
               + (f" matching /{args.regex}/" if args.regex else "") + ".")
         return
+
+    check_quota(len(candidates))
 
     print(f"hee-git-merge: {len(candidates)} candidate(s) found, fetching detail...")
     for i, pr in enumerate(candidates, 1):

--- a/tooling/bin/hee-git-merge
+++ b/tooling/bin/hee-git-merge
@@ -298,6 +298,20 @@ def create_batch_ticket(batch):
     return proc.stdout.strip()
 
 
+# Reserved status dots -- the dataviz skill's real fixed 4-tier status
+# scale (good -> warning -> serious -> critical, references/palette.md's
+# #0ca30c/#fab219/#ec835a/#d03b3b), not an improvised red/yellow/green.
+# Never cycled, never reused as a generic 4th categorical slot. Always
+# paired with a text label on the same or next line -- the dot is a scan
+# aid, never the only signal (a piped/no-emoji terminal still reads fine
+# off the label alone).
+DOT_GOOD = "\U0001F7E2"      # green  -- resolved: ready as-is, or an action just succeeded
+DOT_WARNING = "\U0001F7E1"   # yellow -- open/pending: no decision made yet, nothing wrong
+DOT_SERIOUS = "\U0001F7E0"   # orange -- a real signal needing attention: changes requested,
+                             # or a human explicitly deferred this one
+DOT_CRITICAL = "\U0001F534"  # red    -- blocking: checks failing, conflict, or action failed
+
+
 def checks_summary(pr):
     rollup = pr.get("statusCheckRollup") or []
     if not rollup:
@@ -310,9 +324,29 @@ def checks_summary(pr):
     return f"checks: {len(states)} pending/mixed"
 
 
+def pr_status_dot(pr):
+    """Worst-of-four real signals (checks, review, mergeable) on the fixed
+    good/warning/serious/critical scale -- critical beats serious beats
+    warning beats good, so one blocking signal colors the whole line."""
+    rollup = pr.get("statusCheckRollup") or []
+    states = [c.get("conclusion") or c.get("state") or "?" for c in rollup]
+    checks_failing = any(s in ("FAILURE", "failure", "ERROR", "error") for s in states)
+    checks_passing = bool(states) and all(s in ("SUCCESS", "success") for s in states)
+    review = pr.get("reviewDecision") or "NONE"
+    mergeable = pr.get("mergeable") or "UNKNOWN"
+
+    if checks_failing or mergeable == "CONFLICTING":
+        return DOT_CRITICAL
+    if review == "CHANGES_REQUESTED":
+        return DOT_SERIOUS
+    if checks_passing and review == "APPROVED" and mergeable == "MERGEABLE":
+        return DOT_GOOD
+    return DOT_WARNING
+
+
 def print_synopsis(pr, repo_full):
     print()
-    print(f"[{repo_full}#{pr['number']}] {pr['title']}")
+    print(f"{pr_status_dot(pr)} [{repo_full}#{pr['number']}] {pr['title']}")
     print(f"  {pr['url']}")
     print(f"  +{pr.get('additions', '?')} -{pr.get('deletions', '?')}  "
           f"{pr.get('changedFiles', '?')} files  {checks_summary(pr)}  "
@@ -328,9 +362,9 @@ def do_merge(repo_full, number, method, delete_branch):
         args.append("--delete-branch")
     proc = subprocess.run(["gh", *args], capture_output=True, text=True)
     if proc.returncode == 0:
-        print(f"  merged ({method}).")
+        print(f"  {DOT_GOOD} merged ({method}).")
     else:
-        print(f"  MERGE FAILED:\n{proc.stderr}")
+        print(f"  {DOT_CRITICAL} MERGE FAILED:\n{proc.stderr}")
 
 
 def do_approve(repo_full, number):
@@ -339,9 +373,9 @@ def do_approve(repo_full, number):
         capture_output=True, text=True,
     )
     if proc.returncode == 0:
-        print("  approved.")
+        print(f"  {DOT_GOOD} approved.")
     else:
-        print(f"  APPROVE FAILED:\n{proc.stderr}")
+        print(f"  {DOT_CRITICAL} APPROVE FAILED:\n{proc.stderr}")
 
 
 def estimate_agents(ready):
@@ -461,12 +495,12 @@ def main():
         print(f"{len(candidates)} total open candidate(s), {len(ready)} approved+mergeable.")
         by_repo = estimate_agents(ready)
         if not by_repo:
-            print("No ready work -- 0 agents needed.")
+            print(f"{DOT_WARNING} No ready work -- 0 agents needed.")
             return
         print(f"\n{len(by_repo)} repo(s) with ready work -- real upper bound on useful "
               f"parallel agents (more per repo doesn't help, its own chain still serializes):")
         for repo_full, prs in sorted(by_repo.items()):
-            print(f"  {repo_full}: {len(prs)} PR(s) ready")
+            print(f"  {DOT_GOOD} {repo_full}: {len(prs)} PR(s) ready")
         if len(by_repo) == 1:
             print("\nOne repo -- one agent, sequential, is the real answer here. "
                   "Pencil, not hyperscaler.")
@@ -506,12 +540,20 @@ def main():
         # already happened). Never re-prompt for one under --action=approve.
         if args.action == "approve" and pr.get("reviewDecision") == "APPROVED":
             skipped_approved += 1
-            print(f"\n[{repo_full}#{pr['number']}] already approved -- skipping.")
+            print(f"\n{DOT_GOOD} [{repo_full}#{pr['number']}] already approved "
+                  f"-- auto-skipped, no prompt shown.")
             continue
 
         while True:
             print_synopsis(pr, repo_full)
-            choice = input("  y/N/s/e > ").strip().lower()
+            try:
+                choice = input("  y/N/s/e > ").strip().lower()
+            except EOFError:
+                print(f"\n  {DOT_CRITICAL} no stdin (EOF) -- can't prompt here, stopping "
+                      f"rather than silently skip the rest.")
+                if skipped_approved:
+                    print(f"\n({skipped_approved} PR(s) already approved, auto-skipped -- no re-approval.)")
+                return
             if choice == "y":
                 if args.action == "approve":
                     do_approve(repo_full, pr["number"])
@@ -522,7 +564,7 @@ def main():
                 subprocess.run(["gh", "pr", "diff", str(pr["number"]), "--repo", repo_full])
                 continue
             else:
-                print("  skipped.")
+                print(f"  {DOT_SERIOUS} skipped -- you deferred this one, still open.")
                 break
 
     if skipped_approved:


### PR DESCRIPTION
Real live dogfood fixes from tonight's mass-approve run:

1. **Progress feedback** -- `fetch_prs` + per-PR `fetch_pr_detail` ran
   silently across a 15-PR org-wide search, indistinguishable from a
   hang. Now prints a search line, candidate count, and `[i/n]
   repo#number` progress per detail fetch.

2. **Real 4-tier status dots** -- replaced an improvised red/yellow/green
   with the dataviz skill's actual fixed status scale
   (good/warning/serious/critical, `references/palette.md`'s
   `#0ca30c`/`#fab219`/`#ec835a`/`#d03b3b`), worst-of-four over real
   checks/review/mergeable state. Applied to every synopsis, approve/
   merge result, and summary line -- always paired with a text label,
   never color alone.

3. **EOF-safe prompt loop** -- a run silently auto-skipped PRs Spencer
   didn't mean to skip. `input()` on the `y/N/s/e` prompt now catches
   `EOFError` explicitly and stops with a visible critical-dot message
   instead of letting stdin closing mid-run silently eat the rest of
   the batch.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LJ4munNeuue7eZ9CtbMZkN