### PR TITLE
feat: execution-tier-compat schema + hee-lint annotations fix

### DIFF
--- a/contracts/execution-tier-compat-v1.contract.yaml
+++ b/contracts/execution-tier-compat-v1.contract.yaml
@@ -1,0 +1,64 @@
+apiVersion: hee/v1
+kind: Contract
+metadata:
+  name: execution-tier-compat
+  description: "Real schema for tracking which execution tier (0-token deterministic, narrow local-LLM gate, full Claude reasoning, human-only) each forward-queue item needs, and what tool gap (if any) blocks it. Built 2026-08-24 per Spencer's ask: what do we need to build tool-wise to satisfy everything in the forward queue, to inform prio/effort and better assign work by mode/agent/LLM compatibility."
+  labels:
+    hee.object: "true"
+    hee.contract.type: schema
+    domain: hee
+    scope: capacity-planning
+    topic: execution-tier-compat
+    artifact: contract
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    created_utc: "2026-08-24T00:00:00Z"
+
+spec:
+  intent:
+    - "One place to see, per forward-queue item, which execution tier it needs and whether that tier is actually built yet."
+    - "Tier classification is derived FROM the real compute/* labels already applied to the item's own tracking issue -- not re-asserted here as a second, independently-maintained field. Same one-source-of-truth principle as primitives-entry-schema's tracking_ref design (primitives#6)."
+    - "This feeds prio/effort decisions on the real TCOS Roadmap project (Priority/Effort fields already exist there) and work-assignment across agent/LLM modes -- it does not duplicate or replace those fields."
+
+  related:
+    - contract: "primitives-entry-schema (primitives repo, primitives#6)"
+      relationship: "This contract's tracking_ref/derive-from-labels design is directly modeled on that one's own-tools.yaml tracking_ref field -- same principle, applied to forward-queue capacity planning instead of tool-version provenance."
+    - registry: "primitives/own-tools.yaml"
+      relationship: "Real tie-in, not just shared pattern: every tool listed there is itself a candidate execution_tier_compat entry once it has a real tracking_ref issue with a compute/* label -- own-tools.yaml answers 'what tool is this and where does it live,' this registry answers 'what tier does it run at and is anything blocking that.' Population from own-tools.yaml is a real future pass, not done automatically -- the two files are not merged, to avoid the same two-sources-of-truth risk primitives-entry-schema already explicitly avoided."
+
+  tiers:
+    - id: compute/0-token
+      description: "Pure deterministic tooling, zero LLM call at runtime. Already the cheapest, fastest, safest tier -- prefer this whenever the work is mechanical."
+      built_examples: ["hee-quota", "hee-filter", "hee-publish", "hee-gen-manpages", "hee-fields"]
+    - id: compute/ollama
+      description: "Narrow predicate-gate evaluation (yes/no, <100ms) -- candidate for a local model instead of Claude. Real thesis exists (hee/docs/local-llm-architecture.md, HEE#352); nothing deployed yet as of 2026-08-24."
+      built_examples: []
+    - id: compute/claude-cli
+      description: "Needs real reasoning/judgment -- a full agentic session, not a gate or a script. Currently only proven with Claude; HEE#365 tracks whether a non-Claude agentic CLI can do this too (unverified)."
+      built_examples: ["most real HEE/fleet-ops work tonight"]
+    - id: compute/human-only
+      description: "Physical, legal, or high-stakes-irreversible work. No agent or model executes this alone, regardless of tier maturity elsewhere."
+      built_examples: []
+
+  entry_fields:
+    tracking_ref:
+      type: string
+      required: true
+      format: "owner/repo#N"
+      description: "the real issue this entry describes -- tier is read live off its compute/* label(s), not copied here"
+    required_tier:
+      type: string
+      required: true
+      description: "one of tiers[].id -- snapshot at time of entry, for quick scanning; re-derive from the live label if it looks stale"
+    blocking_tool_gap:
+      type: string
+      required: false
+      description: "what needs to be built before this item can move at its required tier -- null/omitted if nothing is blocking"
+    notes:
+      type: string
+      required: false
+
+  file_shape:
+    description: "Real instance lives in hee/registries/execution-tier-compat.registry.v1.yaml -- kind: Registry, spec.entries as the real, live-tracked list, same shape as primitives' four registries."
+    real_kind: Registry

--- a/hee/registries/execution-tier-compat.registry.v1.yaml
+++ b/hee/registries/execution-tier-compat.registry.v1.yaml
@@ -1,0 +1,64 @@
+apiVersion: hee/v1
+kind: Registry
+metadata:
+  name: execution-tier-compat
+  description: "Real, live-tracked list of forward-queue items (TCOS Roadmap project Status = 'Near Future Todo' / 'In Future'), each mapped to its required execution tier and any real blocking tool gap. Schema: contracts/execution-tier-compat-v1.contract.yaml."
+  labels:
+    hee.object: "true"
+    domain: hee
+    scope: capacity-planning
+    topic: execution-tier-compat-registry
+    artifact: registry
+  annotations:
+    inuid: null
+    inuid_null_reason: bootstrap
+    updated-at: "2026-08-24T16:45:00Z"
+
+spec:
+  ts_human: 2026-08-24_1645
+
+  invariants:
+    - "Every entry's required_tier must match a real compute/* label on tracking_ref at time of last review -- re-check the live label before trusting this file if it looks old."
+    - "Real forward-queue snapshot as of 2026-08-24: 7 items, all Status='Near Future Todo', zero in 'In Future' (pulled live via the TCOS Roadmap project GraphQL API, not estimated)."
+
+  entries:
+    - tracking_ref: "Twin-Cities-Open-Systems/human-execution-engine#216"
+      required_tier: compute/claude-cli
+      blocking_tool_gap: null
+      notes: "IMPLEMENTATION_MANUAL -- real authored-content work, no tool gap, just needs a real writing pass."
+
+    - tracking_ref: "Twin-Cities-Open-Systems/fleet-ops#201"
+      required_tier: compute/claude-cli
+      blocking_tool_gap: "glass-browser has no authenticated profile/allowed-task mechanism yet -- real UI-automation gap, not a reasoning gap. See feedback_ui_gap_to_glass_ops-style tracking."
+      notes: "Squarespace domain-invite acceptance blocked on this specifically."
+
+    - tracking_ref: "Twin-Cities-Open-Systems/fleet-ops#200"
+      required_tier: compute/human-only
+      blocking_tool_gap: null
+      notes: "Board Ops hardware hacking (Ducky Ops keyboard) -- physical work, agent's role is limited to tracking/documenting, not executing."
+
+    - tracking_ref: "Twin-Cities-Open-Systems/tcos-www#25"
+      required_tier: compute/claude-cli
+      blocking_tool_gap: null
+      notes: "Smooth UI/UX -- standard real design+code work, no tool gap."
+
+    - tracking_ref: "Twin-Cities-Open-Systems/tcos-www#15"
+      required_tier: compute/claude-cli
+      blocking_tool_gap: null
+      notes: "Competing epoch counters (2038 rollover) -- real feature build, no tool gap."
+
+    - tracking_ref: "Twin-Cities-Open-Systems/human-execution-engine#248"
+      required_tier: compute/claude-cli
+      blocking_tool_gap: "Real SNMP tooling doesn't exist yet (hee-net covers finger/gopher only, not snmp) -- needed before the MIB (PEN 66550) can actually be served, not just designed."
+      notes: "Epic: OWNER-ROOT-MIB. Design/authoring is claude-cli tier; once built, real SNMP polling could move to compute/0-token."
+
+    - tracking_ref: "Twin-Cities-Open-Systems/human-execution-engine#210"
+      required_tier: compute/claude-cli
+      blocking_tool_gap: null
+      notes: "Kernel-level HEE verification (IMA/EVM). Research/design is claude-cli tier; real deployment of any kernel module or IMA/EVM policy is compute/human-only regardless -- flagged, not double-labeled, since the contract's tiers are meant to be additive per real-world risk, not just per-task-shape."
+
+  example_entries:
+    - tracking_ref: "Twin-Cities-Open-Systems/human-execution-engine#000"
+      required_tier: compute/0-token
+      blocking_tool_gap: null
+      notes: "Illustrative only -- not a real tracked item."

--- a/tooling/bin/hee-lint
+++ b/tooling/bin/hee-lint
@@ -55,11 +55,11 @@ check_file() {
     }
     my $meta = $2;
 
-    if ($meta !~ /(^|\n)\s*annotations:\s*\n(.*?)(\n\s*\S|$)/s) {
+    if ($meta !~ /(^|\n)(\s*)annotations:\s*\n((?:\2[ \t]+\S.*\n?)*)/s) {
       print "🔴 🟦 b # ERROR: missing metadata.annotations: $ARGV\n";
       exit 3;
     }
-    my $ann = $2;
+    my $ann = $3;
 
     if ($ann =~ /(^|\n)\s*inuid:\s*(.*?)\s*(\n|$)/s) {
       $inuid = 1;


### PR DESCRIPTION
Real work per Spencer's ask (2026-08-24): what tools we need to build to satisfy everything in the forward queue, for prio/effort + mode/agent/LLM compat assignment.

- contracts/execution-tier-compat-v1.contract.yaml + hee/registries/execution-tier-compat.registry.v1.yaml -- real instance covering all 7 items currently in the TCOS Roadmap's forward queue (Near Future Todo). Tier derived from real compute/* labels, applied live. Two real blocking gaps found: fleet-ops#201 needs glass-browser auth-profile support, HEE#248 needs real SNMP tooling.
- tooling/bin/hee-lint: real annotations-block regex fix (false 'missing inuid_null_reason' on correctly-formed 2-line blocks -- 7 of the repo's real lint failures were this).

Pushed via the GitHub Contents API directly, not local git -- a real, confirmed shared-clone/worktree collision on this host (independently hit by a peer session too) was silently evicting commits and flipping checked-out branches mid-task. Content is verified byte-for-byte via a fresh API read, not just trusted from push output.